### PR TITLE
fix: add Back to Home navigation link on Sign In page

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -45,12 +45,12 @@ export const Login = () => {
           <div className="flex justify-start -mb-2">
             
               href="/"
-              className="flex items-center gap-1 text-xs text-slate-400 hover:text-violet-400 transition-colors duration-200 font-semibold"
+              className="group flex items-center gap-1 text-xs text-slate-400 hover:text-violet-400 transition-colors duration-200 font-semibold"
             >
-              ← Back to Home
+              <span className="inline-block transition-transform duration-200 group-hover:-translate-x-1">←</span>
+              Back to Home
             </a>
-          </div>
-          
+          </div>       
           {/* Logo Brand Header */}
           <div className="text-center space-y-3">
             <div className="inline-flex w-12 h-12 rounded-2xl bg-gradient-to-tr from-violet-600 via-indigo-600 to-blue-600 items-center justify-center shadow-lg shadow-indigo-500/20 mx-auto">

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -40,6 +40,16 @@ export const Login = () => {
         className="w-full max-w-md relative z-10"
       >
         <Card className="backdrop-blur-2xl bg-slate-950/40 border-slate-800/40 p-8 shadow-2xl space-y-6">
+
+	{/* Back to Home */}
+          <div className="flex justify-start -mb-2">
+            
+              href="/"
+              className="flex items-center gap-1 text-xs text-slate-400 hover:text-violet-400 transition-colors duration-200 font-semibold"
+            >
+              ← Back to Home
+            </a>
+          </div>
           
           {/* Logo Brand Header */}
           <div className="text-center space-y-3">


### PR DESCRIPTION
## What this PR does
Adds a "← Back to Home" navigation link on the Sign In page that redirects 
users to the homepage (/), improving navigation flow and user experience.

## Changes Made
- Added a subtle "← Back to Home" link at the top of the login card
- Styled consistently with RankerHub's dark theme using Tailwind CSS
- Hover effect changes color to violet to match the existing theme
- Fully responsive on all screen sizes

## Related Issue
Closes #3

## Program Classification
- [x] GSSoC26

## Type of Change
- [x] Bug fix / Enhancement