### PR TITLE
fix(mobile-sidebar): securely terminate session on mobile logout

### DIFF
--- a/src/components/layout/MobileSidebar.jsx
+++ b/src/components/layout/MobileSidebar.jsx
@@ -20,6 +20,7 @@ import { Github } from "../ui/Icons";
 import { sidebarLinks } from "../../constants";
 import LogoutConfirmModal from "../ui/LogoutConfirmModal";
 import logo from "../../assets/logo.png";
+import { useAuth } from "../../context/AuthContext";
 
 const iconMap = {
   Home,
@@ -43,6 +44,7 @@ const isLinkActive = (pathname, path) => {
 };
 
 export const MobileSidebar = ({ isOpen, close }) => {
+  const { logout } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
@@ -51,10 +53,15 @@ export const MobileSidebar = ({ isOpen, close }) => {
     setShowLogoutConfirm(true);
   };
 
-  const confirmLogout = () => {
+  const confirmLogout = async () => {
     setShowLogoutConfirm(false);
     close();
-    navigate("/");
+    try {
+      await logout();
+      navigate("/");
+    } catch (error) {
+      console.error("Mobile logout failure:", error);
+    }
   };
 
   return (


### PR DESCRIPTION
### Description
This Pull Request resolves the security leak where mobile users clicking "Logout" in the navigation drawer would have their view redirected to the landing page, but their active Firebase authentication session remained fully active and authenticated.

### Key Changes
- Imported `useAuth` from the authentication context inside `src/components/layout/MobileSidebar.jsx`.
- Updated the `confirmLogout` handler to securely call `await logout()` before navigating.

### Verification Done
- Verified that the Firebase auth token is correctly revoked and the user is securely signed out from Firebase on mobile logout.
- Verified that restricted routes (like `/dashboard` and `/profile`) are no longer accessible after logging out.
- Ran a clean production build (`npm run build`) which succeeded in 6.88s.
- Ran code lint checks (`npm run lint`) with 0 errors.

Closes #35