### PR TITLE
fix(dashboard): dynamically hydrate achievements and correct active s…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -287,29 +288,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -512,6 +490,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.12.tgz",
       "integrity": "sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
@@ -578,6 +557,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.12.tgz",
       "integrity": "sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.12",
         "@firebase/component": "0.7.3",
@@ -594,6 +574,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
       "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/logger": "0.5.1"
       }
@@ -1047,6 +1028,7 @@
       "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1673,6 +1655,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1832,6 +1815,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2090,6 +2074,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2469,6 +2454,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3236,6 +3222,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3965,6 +3952,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4012,6 +4000,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4234,6 +4223,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4243,6 +4233,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4795,6 +4786,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5108,6 +5100,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/dashboard/RankPreview.jsx
+++ b/src/components/dashboard/RankPreview.jsx
@@ -114,7 +114,7 @@ export const RankPreview = () => {
                   {user.points?.totalPoints?.toLocaleString() || 0}
                 </span>
                 <span className="inline-flex items-center gap-0.5 text-[10px] font-bold text-orange-500 dark:text-orange-400">
-                  🔥 {user.streak || 1}d streak
+                  🔥 {user.streak ?? 0}d streak
                 </span>
               </div>
             </div>

--- a/src/components/dashboard/StatsCards.jsx
+++ b/src/components/dashboard/StatsCards.jsx
@@ -35,7 +35,7 @@ export const StatsCards = () => {
 
   const totalPoints = userData?.points?.totalPoints || 0;
   const gitCommits = userData?.githubStats?.commits || 0;
-  const streak = userData?.streak || 1;
+  const streak = userData?.streak ?? 0;
 
   const stats = [
     {

--- a/src/pages/Achievements.jsx
+++ b/src/pages/Achievements.jsx
@@ -14,23 +14,78 @@ import Card from "../components/ui/Card";
 import SectionHeader from "../components/ui/SectionHeader";
 import ComingSoonCard from "../components/ui/ComingSoonCard";
 import { systemBadges } from "../constants";
+import { useAuth } from "../context/AuthContext";
 
 export const Achievements = () => {
+  const { userData } = useAuth();
   const [selectedBadge, setSelectedBadge] = useState(systemBadges[0]);
 
-  // Enhanced mock progress data for achievements
+  // Extract metrics dynamically from the live Firestore user document
+  const commits = userData?.githubStats?.commits || 0;
+  const streak = userData?.streak || 0;
+  const codingVersePoints = userData?.points?.codingVersePoints || 0;
+
+  // Calculate dynamic progress mapping for the 4 badges
   const badgeProgress = {
     b1: { unlocked: true, unlockedAt: "May 10, 2026", progress: 100, current: 1, target: 1, label: "First 100 users whitelist" },
-    b2: { unlocked: false, unlockedAt: null, progress: 45, current: 45, target: 100, label: "GitHub Commits Audited" },
-    b3: { unlocked: false, unlockedAt: null, progress: 80, current: 8, target: 10, label: "Daily Consistency Streaks" },
-    b4: { unlocked: false, unlockedAt: null, progress: 20, current: 1, target: 5, label: "Frontend Arenas Solved" }
+    b2: { 
+      unlocked: commits >= 100, 
+      unlockedAt: commits >= 100 ? "Verified" : null, 
+      progress: Math.min(100, Math.round((commits / 100) * 100)), 
+      current: commits, 
+      target: 100, 
+      label: "GitHub Commits Audited" 
+    },
+    b3: { 
+      unlocked: streak >= 10, 
+      unlockedAt: streak >= 10 ? "Verified" : null, 
+      progress: Math.min(100, Math.round((streak / 10) * 100)), 
+      current: streak, 
+      target: 10, 
+      label: "Daily Consistency Streaks" 
+    },
+    b4: { 
+      unlocked: codingVersePoints >= 100, 
+      unlockedAt: codingVersePoints >= 100 ? "Verified" : null, 
+      progress: Math.min(100, Math.round((codingVersePoints / 100) * 100)), 
+      current: codingVersePoints, 
+      target: 100, 
+      label: "Frontend Arenas Solved (XP)" 
+    }
   };
 
+  // Dynamically calculate daily quests completion from actual platform performance
   const dailyQuests = [
-    { id: "q1", title: "GitRank Explorer", description: "Audit commits in any public repository", xp: 50, progress: 0, target: 1, completed: false },
-    { id: "q2", title: "Consistency Streak", description: "Maintain your daily streak in CodingOwl", xp: 100, progress: 1, target: 1, completed: true },
-    { id: "q3", title: "Verse Conqueror", description: "Solve a medium-difficulty problem in CodingVerse", xp: 150, progress: 1, target: 2, completed: false }
+    { 
+      id: "q1", 
+      title: "GitRank Explorer", 
+      description: "Audit commits in any public repository", 
+      xp: 50, 
+      progress: commits > 0 ? 1 : 0, 
+      target: 1, 
+      completed: commits > 0 
+    },
+    { 
+      id: "q2", 
+      title: "Consistency Streak", 
+      description: "Maintain your daily streak in CodingOwl", 
+      xp: 100, 
+      progress: streak > 0 ? 1 : 0, 
+      target: 1, 
+      completed: streak > 0 
+    },
+    { 
+      id: "q3", 
+      title: "Verse Conqueror", 
+      description: "Solve a medium-difficulty problem in CodingVerse (40 XP each)", 
+      xp: 150, 
+      progress: Math.min(2, Math.floor(codingVersePoints / 40)), 
+      target: 2, 
+      completed: codingVersePoints >= 80 
+    }
   ];
+
+  const unlockedCount = Object.values(badgeProgress).filter((b) => b.unlocked).length;
 
   return (
     <div className="space-y-8">
@@ -67,7 +122,7 @@ export const Achievements = () => {
               Developer Badges
             </h3>
             <span className="text-xs font-bold text-slate-400 bg-slate-100 dark:bg-slate-800/60 px-2.5 py-1 rounded-full border border-slate-200/50 dark:border-slate-800/50">
-              1 of 4 Unlocked
+              {unlockedCount} of 4 Unlocked
             </span>
           </div>
 

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -851,7 +851,7 @@ export const GitRank = () => {
 
                       {/* Streak flame cell */}
                       <td className="py-4 px-4 text-center font-bold text-orange-600 dark:text-orange-400 whitespace-nowrap">
-                        🔥 {u.streak || 1} days
+                        🔥 {u.streak ?? 0} days
                       </td>
 
                       {/* Commits count cell */}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -167,7 +167,7 @@ export const Profile = () => {
   const referralPoints = userData?.points?.referralPoints || 0;
   const streakPoints = userData?.points?.streakPoints || 0;
   const codingVersePoints = userData?.points?.codingVersePoints || 0;
-  const streak = userData?.streak || 1;
+  const streak = userData?.streak ?? 0;
   const pointsEngines = [
     { label: "GitRank Points", value: gitRankPoints, color: "bg-blue-500" },
     { label: "CodingVerse Points", value: codingVersePoints, color: "bg-purple-500" },
@@ -599,8 +599,8 @@ export const Profile = () => {
               let unlocked = false;
               if (badge.id === "b1") unlocked = true;
               if (badge.id === "b2" && gitRankPoints >= 100) unlocked = true;
-              if (badge.id === "b3" && streak >= 5) unlocked = true;
-              if (badge.id === "b4" && referralPoints >= 100) unlocked = true;
+              if (badge.id === "b3" && streak >= 10) unlocked = true;
+              if (badge.id === "b4" && codingVersePoints >= 100) unlocked = true;
 
               return (
                 <div


### PR DESCRIPTION
### Description
This Pull Request resolves multiple inconsistencies and UI bugs across the Achievements and Profile dashboards:
1. **Dynamic Achievements & Quests**: Fully connects the Achievements page to the live Firestore context (`useAuth`). It dynamically maps progress percentages, current/target counts, and active daily quests based on the user's actual database state.
2. **Unified Badge Rules**: Standardized the `b4` "CSS Sorceress" badge to unlock when `codingVersePoints >= 100` across both `Achievements.jsx` and `Profile.jsx`.
3. **Streak Display Corrections**: Resolved a JavaScript falsy coercion check (`|| 1`) across `Profile.jsx`, `GitRank.jsx`, `RankPreview.jsx`, and `StatsCards.jsx`. Users with `0` day streaks will now accurately display as `0` instead of incorrectly showing `1`.

### Key Changes
- Hydrated `src/pages/Achievements.jsx` with the user context from Firestore.
- Replaced falsy active streak displays (`|| 1`) with nullish coalescing checks (`?? 0`).
- Unified and implemented badge unlocking logic based on user styling points threshold.

### Verification Done
- Verified that all achievements and quests update in real-time when Firestore data changes.
- Checked that `0` day streaks are represented correctly as `0` Days on all stats cards and previews.
- Verified compilation with a clean production bundle via `npm run build`.
- Audited styles and types with ESLint (`npm run lint`), passing successfully.

Closes #41