### PR TITLE
fix(ci): use pull_request_target event for automated triage and welco…

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -3,7 +3,7 @@ name: Triage Automation
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -44,7 +44,7 @@ jobs:
             });
 
       - name: Pull Request Triage
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -3,7 +3,7 @@ name: Welcome Contributor
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:


### PR DESCRIPTION
### Description
This Pull Request resolves the 403 permission failures on GitHub Action workflow runs triggered by Pull Requests opened from forks.

### Key Changes
- Changed trigger events in `.github/workflows/triage.yml` and `.github/workflows/welcome.yml` from `pull_request` to `pull_request_target`.
- Updated event name check condition in `triage.yml` to match `pull_request_target`.

### Verification Done
- Verified that no untrusted code checkout or arbitrary script execution is performed in these workflows, keeping the use of `pull_request_target` entirely safe.
- Verified syntax validity of YAML files.

Closes #43 