### PR TITLE
feat: add global rate limit interceptor and warning banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,17 +2,22 @@ import React from "react";
 import { HashRouter } from "react-router-dom";
 import { ThemeProvider } from "./context/ThemeContext";
 import { AuthProvider } from "./context/AuthContext";
+import { RateLimitProvider } from "./context/RateLimitContext";
 import AppRoutes from "./routes/AppRoutes";
 import ErrorBoundary from "./components/ui/ErrorBoundary";
+import RateLimitBanner from "./components/ui/RateLimitBanner";
 
 function App() {
   return (
     <ErrorBoundary>
       <ThemeProvider>
         <AuthProvider>
-          <HashRouter>
-            <AppRoutes />
-          </HashRouter>
+          <RateLimitProvider>
+            <HashRouter>
+              <RateLimitBanner />
+              <AppRoutes />
+            </HashRouter>
+          </RateLimitProvider>
         </AuthProvider>
       </ThemeProvider>
     </ErrorBoundary>

--- a/src/components/ui/RateLimitBanner.jsx
+++ b/src/components/ui/RateLimitBanner.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { useRateLimit } from '../../context/RateLimitContext';
+
+const RateLimitBanner = () => {
+  const { isRateLimited, resetRateLimit } = useRateLimit();
+
+  if (!isRateLimited) return null;
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[9999] bg-rose-500 text-white p-3 shadow-lg flex items-center justify-between transition-all duration-300">
+      <div className="flex items-center gap-3 max-w-7xl mx-auto w-full px-4">
+        <AlertTriangle size={20} className="shrink-0" />
+        <p className="text-sm md:text-base font-medium">
+          GitHub API rate limit exceeded! Please wait a while or authenticate to continue tracking stats.
+        </p>
+      </div>
+      <button
+        onClick={resetRateLimit}
+        className="shrink-0 p-1.5 hover:bg-rose-600 rounded-md transition-colors mr-2 sm:mr-6"
+        aria-label="Close warning"
+      >
+        <X size={18} />
+      </button>
+    </div>
+  );
+};
+
+export default RateLimitBanner;

--- a/src/context/RateLimitContext.jsx
+++ b/src/context/RateLimitContext.jsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import axios from 'axios';
+
+const RateLimitContext = createContext();
+
+export const useRateLimit = () => useContext(RateLimitContext);
+
+export const RateLimitProvider = ({ children }) => {
+  const [isRateLimited, setIsRateLimited] = useState(false);
+
+  useEffect(() => {
+    const interceptor = axios.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (
+          error.response &&
+          error.response.status === 403 &&
+          error.response.headers['x-ratelimit-remaining'] === '0'
+        ) {
+          setIsRateLimited(true);
+        }
+        return Promise.reject(error);
+      }
+    );
+
+    return () => {
+      axios.interceptors.response.eject(interceptor);
+    };
+  }, []);
+
+  const resetRateLimit = () => setIsRateLimited(false);
+
+  return (
+    <RateLimitContext.Provider value={{ isRateLimited, resetRateLimit }}>
+      {children}
+    </RateLimitContext.Provider>
+  );
+};


### PR DESCRIPTION
### 📝 Description
This PR resolves the issue of unhandled GitHub API rate limits. It introduces an Axios interceptor that specifically listens for `403 Forbidden` status codes accompanied by the `x-ratelimit-remaining: 0` header. When triggered, it gracefully informs the user via a global warning banner.

#### 🚀 Changes Introduced:
* **Context Provider (`RateLimitContext.jsx`):** Added a global context and an Axios interceptor to monitor all outgoing API requests for rate limit errors.
* **UI Component (`RateLimitBanner.jsx`):** Built a responsive, accessible warning banner using Lucide React icons that alerts users when they hit the 60/hr or 5000/hr limit.
* **App Integration (`App.jsx`):** Wrapped the application with the `RateLimitProvider` and mounted the `RateLimitBanner` so it persists across all routes without disrupting the layout.

#### 📸 Screenshots / Proof of Concept
<img width="1920" height="1013" alt="image" src="https://github.com/user-attachments/assets/e17250e9-0fad-4887-b092-982735a1dbe8" />

#### ✅ Checklist
- [x] Tested locally to ensure the interceptor properly catches `403` status.
- [x] Banner renders correctly across both Desktop and Mobile views.
- [x] No sensitive `.env` files were committed.
- [x] Follows project's semantic commit and styling guidelines.

Closes #32