### PR TITLE
fix: replace hardcoded city and streak defaults on new user signup

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -110,8 +110,8 @@ export const AuthProvider = ({ children }) => {
           email: authUser.email || "",
           avatar,
           onboardingStatus: "incomplete",
-          city: "Mumbai",
-          streak: 1,
+          city: "",
+          streak: 0,
           lastLogin: new Date().toISOString(),
           createdAt: new Date().toISOString(),
           points: {


### PR DESCRIPTION
## Description

When a first-time user signed in via GitHub OAuth, `AuthContext.jsx` wrote `city: "Mumbai"` and `streak: 1` into their Firestore document before onboarding ran. This meant:

- Every new user appeared as a Mumbai resident in leaderboard city filters regardless of their real location.
- Every new account started with a 1-day streak despite having performed no activity.

Both fields are now initialised to neutral values: `city` to an empty string (filled in during onboarding) and `streak` to `0` (no activity has occurred yet).

**Before:**
```js
city: "Mumbai",
streak: 1,
```

**After:**
```js
city: "",
streak: 0,
```

## Related Issue
Fixes #33

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
N/A (Firestore document field change, no UI diff)

## Testing Done
- [x] Signed in with a GitHub account that had never used the app.
- [x] Inspected the newly created Firestore document and confirmed `city: ""` and `streak: 0`.
- [x] Verified that existing users (where `docSnap.exists()` is true) are unaffected.
- [x] Command run: `npm run lint`
- [x] Command run: `npm run build`
- [x] Visual verification on local dev server (`http://localhost:5173`)

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] Any dependent changes have been merged and published in downstream modules.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **GSSoC 2026** and **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the [Contributing Guidelines](https://github.com/indresh404/RankerHub/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://github.com/indresh404/RankerHub/blob/main/docs/CODE_OF_CONDUCT.md).