### PR TITLE
fix: replace fabricated stat fallbacks with honest zeros in fetchGitHubStats

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -199,8 +199,8 @@ export const AuthProvider = ({ children }) => {
         const commitsRes = await axios.get(`https://api.github.com/search/commits?q=author:${username}`, { headers });
         commits = commitsRes.data.total_count || 0;
       } catch (err) {
-        console.warn("Commits retrieval warning, using fallback:", err);
-        commits = publicRepos * 12; 
+        console.warn("Commits retrieval failed; score will be incomplete until next refresh:", err);
+        commits = 0;
       }
 
       // 4. Fetch total pull requests
@@ -209,8 +209,8 @@ export const AuthProvider = ({ children }) => {
         const prsRes = await axios.get(`https://api.github.com/search/issues?q=author:${username}+type:pr`, { headers });
         prs = prsRes.data.total_count || 0;
       } catch (err) {
-        console.warn("PRs retrieval warning:", err);
-        prs = Math.floor(publicRepos * 1.5);
+        console.warn("PRs retrieval failed; score will be incomplete until next refresh:", err);
+        prs = 0;
       }
 
       // 5. Fetch total reviews (PRs reviewed by user)
@@ -219,8 +219,8 @@ export const AuthProvider = ({ children }) => {
         const reviewsRes = await axios.get(`https://api.github.com/search/issues?q=reviewed-by:${username}`, { headers });
         reviews = reviewsRes.data.total_count || 0;
       } catch (err) {
-        console.warn("Reviews retrieval warning:", err);
-        reviews = Math.floor(prs * 0.2); // safe fallback
+        console.warn("Reviews retrieval failed; score will be incomplete until next refresh:", err);
+        reviews = 0;
       }
 
       // Calculate initial GitRank points securely based on real work only:
@@ -239,16 +239,18 @@ export const AuthProvider = ({ children }) => {
       };
     } catch (error) {
       console.error("Error executing GitHub stats fetcher snapshot:", error);
-      // Clean fallback if API breaks entirely or token is invalid
+      // Return honest zeros when the API is unreachable so no fabricated
+      // points are written to Firestore. The caller can surface a
+      // "score pending" state and re-fetch on the next login.
       return {
-        commits: 5,
-        prs: 1,
+        commits: 0,
+        prs: 0,
         reviews: 0,
-        publicRepos: 3,
+        publicRepos: 0,
         stars: 0,
-        followers: 1,
+        followers: 0,
         primaryLanguage: "JavaScript",
-        gitRankPoints: 15 // safe baseline
+        gitRankPoints: 0
       };
     }
   };


### PR DESCRIPTION
## Description

`fetchGitHubStats` in `AuthContext.jsx` estimated commit, PR, and review counts from `publicRepos` when the GitHub Search API calls failed:

```js
commits = publicRepos * 12;      // fabricated
prs     = Math.floor(publicRepos * 1.5);  // fabricated
reviews = Math.floor(prs * 0.2); // fabricated
```

These fabricated numbers fed directly into `gitRankPoints = (commits * 2) + (prs * 5) + (reviews * 10)` and were written to Firestore as permanent scores. A user with 50 public repos and zero actual commits would receive 1,200 phantom points and outrank genuine contributors on the leaderboard.

The outer catch block (triggered when the profile fetch itself failed) also returned hardcoded non-zero values (`commits: 5`, `prs: 1`, `gitRankPoints: 15`), which had the same effect.

**Fix:** every catch block that previously set a fabricated estimate now sets the counter to `0`. Only data that has been verified by a successful API response contributes to the score. The warning messages are updated to signal that the score is incomplete and will be refreshed on the next login.

**Before:**
```js
// commit fallback
commits = publicRepos * 12;

// PR fallback
prs = Math.floor(publicRepos * 1.5);

// review fallback
reviews = Math.floor(prs * 0.2);

// outer catch
return { commits: 5, prs: 1, reviews: 0, publicRepos: 3, followers: 1, gitRankPoints: 15 };
```

**After:**
```js
// commit fallback
commits = 0;

// PR fallback
prs = 0;

// review fallback
reviews = 0;

// outer catch
return { commits: 0, prs: 0, reviews: 0, publicRepos: 0, followers: 0, gitRankPoints: 0 };
```

## Related Issue
Fixes #34

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
N/A (logic change, no visual diff)

## Testing Done
- [x] Simulated a Search API failure by temporarily revoking the OAuth token scope for `search`.
- [x] Confirmed that `gitRankPoints` written to Firestore was `0` instead of a fabricated estimate.
- [x] Verified that a user whose API calls all succeed is unaffected by this change.
- [x] Command run: `npm run lint`
- [x] Command run: `npm run build`
- [x] Visual verification on local dev server (`http://localhost:5173`)

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **GSSoC 2026** and **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the [Contributing Guidelines](https://github.com/indresh404/RankerHub/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://github.com/indresh404/RankerHub/blob/main/docs/CODE_OF_CONDUCT.md).