### PR TITLE
fix(friends): persist connection followingIds state in module scope a…

### DIFF
--- a/src/services/friendsService.js
+++ b/src/services/friendsService.js
@@ -97,6 +97,8 @@ const developers = [
   }
 ];
 
+let activeFollowingIds = ["sarah_c", "marcusv", "aiko_t", "sofia_r"];
+
 export const initialConnectionState = {
   followingIds: ["sarah_c", "marcusv", "aiko_t", "sofia_r"],
   followerIds: ["sarah_c", "elena_r", "tariq_m", "leo_d", "priya_shah"]
@@ -104,16 +106,19 @@ export const initialConnectionState = {
 
 export const getSocialGraph = () => ({
   developers,
-  followingIds: initialConnectionState.followingIds,
+  followingIds: activeFollowingIds,
   followerIds: initialConnectionState.followerIds
 });
 
 export const toggleFollowStatus = (followingIds, developerId) => {
+  let updatedIds;
   if (followingIds.includes(developerId)) {
-    return followingIds.filter((id) => id !== developerId);
+    updatedIds = followingIds.filter((id) => id !== developerId);
+  } else {
+    updatedIds = [...followingIds, developerId];
   }
-
-  return [...followingIds, developerId];
+  activeFollowingIds = updatedIds;
+  return updatedIds;
 };
 
 export const hydrateConnections = ({ followingIds, followerIds }) => {


### PR DESCRIPTION
### Description
This Pull Request resolves a logical state persistence bug where switching between tabs in the Friends section (Friends, Followers, Following) would completely wipe and reset the user's follow/unfollow actions back to mock defaults.

### Key Changes
- Caching active connection `followingIds` inside a module-level variable (`activeFollowingIds`) in `src/services/friendsService.js`.
- Modified `toggleFollowStatus` to persist state directly to the module-level variable before returning.

### Verification Done
- Verified that following a suggested developer and immediately switching tabs properly retains their follow status, successfully persisting the connection state in the SPA session.
- Successfully built and linted the project.

Closes #46