### PR TITLE
fix(onboarding): restrict future dates and enforce minimum age of 13 …

### DIFF
--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -129,6 +129,23 @@ export const Onboarding = () => {
       setIsLoading(false);
       return;
     }
+
+    // Validate that DOB is in the past and user is at least 13 years old (COPPA compliance)
+    const today = new Date().toISOString().split("T")[0];
+    if (dob > today) {
+      setError("Date of birth cannot be in the future.");
+      setIsLoading(false);
+      return;
+    }
+
+    const birthDate = new Date(dob);
+    const ageLimitDate = new Date();
+    ageLimitDate.setFullYear(ageLimitDate.getFullYear() - 13);
+    if (birthDate > ageLimitDate) {
+      setError("You must be at least 13 years old to join RankerHub.");
+      setIsLoading(false);
+      return;
+    }
     if (!selectedCollege || !collegesList.includes(selectedCollege)) {
       setError("Please select a college from the searchable dropdown list.");
       setIsLoading(false);
@@ -415,6 +432,7 @@ export const Onboarding = () => {
                 <input
                   type="date"
                   value={dob}
+                  max={new Date().toISOString().split("T")[0]}
                   onChange={(e) => setDob(e.target.value)}
                   className="w-full px-4 py-3 text-sm rounded-xl border border-slate-200 dark:border-slate-800 bg-white/40 dark:bg-slate-950/20 focus:outline-none focus:ring-2 focus:ring-violet-500/20 focus:border-violet-500 dark:text-white transition-all"
                 />


### PR DESCRIPTION
### Description
This Pull Request resolves a compliance and validation bug in the onboarding flow (`Onboarding.jsx`) where contributors could select future birthdates or register as under-age users without error.

### Key Changes
- Restricted HTML calendar selection to past dates by adding the `max` attribute to the DOB `<input type="date">` tag.
- Added strict submit-handler validation checks to prevent future dates and enforce a standard 13-year minimum age requirement (COPPA safety compliance).

### Verification Done
- Verified that all future dates are disabled in the browser's date-picker dialog.
- Confirmed that entering a future date or an age under 13 triggers clear error messages in the form.
- Ran a clean production build (`npm run build`) and lint checks, passing successfully.

Closes #55