### PR TITLE
fix(firestore): remove hardcoded city == 'Mumbai' constraint from users create rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -23,9 +23,10 @@ service cloud.firestore {
       // Leaderboard requires anyone logged in to view profiles
       allow read: if isAuthenticated();
 
-      // Creation: A logged in user can provision a skeletal profile or onboarding document
-      allow create: if isOwner(uid) 
-        && request.resource.data.city == "Mumbai"
+      // Creation: A logged in user can provision a skeletal profile or onboarding document.
+      // The city field is not restricted to any specific value so users from all cities
+      // can create their profile during onboarding.
+      allow create: if isOwner(uid)
         && (request.resource.data.onboardingStatus == "incomplete" || request.resource.data.onboardingStatus == "complete");
 
       // RULE 1: Allow social profile updates (LinkedIn, Instagram, Discord) ANYTIME


### PR DESCRIPTION
## Description

The Firestore security rule for creating a user document in `firestore.rules` contained a hardcoded city constraint:

```
allow create: if isOwner(uid)
  && request.resource.data.city == "Mumbai"
  ...
```

This blocked every user whose `city` field is not `"Mumbai"` from creating their profile during onboarding. The constraint is almost certainly a development placeholder that was never removed; it makes the application effectively unusable for any user outside Mumbai.

## Root Cause

A hardcoded string literal `"Mumbai"` was used in the Firestore security rule without being replaced with a proper constraint or removed before going to production.

## Related Issue

Closes #79

## Type of Change

- [x] Bug fix

## Changes Made

- `firestore.rules`: removed the `&& request.resource.data.city == "Mumbai"` condition from the `allow create` rule for `/users/{uid}`. The `onboardingStatus` check already provides the necessary guard; city validation belongs in client-side form validation, not in the security rule.

## Screenshots or Demo

Not applicable.

## Testing Done

1. Attempt to create a profile with `city: "Delhi"`. Confirm the profile is created successfully.
2. Attempt to create a profile with `city: "Mumbai"`. Confirm it still works as before.
3. Verify that the `onboardingStatus` requirement (`incomplete` or `complete`) still applies.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue

Could you please add the appropriate NSoC'26 label to this PR? It helps with tracking and scoring under NSoC 2026. Thank you!