### PR TITLE
fix(security): move GitHub OAuth access token from sessionStorage to React state

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -22,6 +22,12 @@ export const AuthProvider = ({ children }) => {
   const [userData, setUserData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isOnboarding, setIsOnboarding] = useState(false);
+  // GitHub OAuth access token kept in React state only -- never written to
+  // sessionStorage or localStorage. Storing it in Web Storage exposes it to
+  // any JavaScript running on the page (XSS). Keeping it in memory means it
+  // is lost on page refresh, but the token is only needed once after login
+  // to call fetchGitHubStats, so this trade-off is acceptable.
+  const [ghAccessToken, setGhAccessToken] = useState(null);
 
   // Listen to Auth State Changed
   useEffect(() => {
@@ -92,8 +98,8 @@ export const AuthProvider = ({ children }) => {
       const githubId = additionalInfo?.profile?.id || null;
       const avatar = additionalInfo?.profile?.avatar_url || authUser.photoURL || "";
 
-      // Store GitHub accessToken in sessionStorage securely (non-persistent across tabs for security)
-      sessionStorage.setItem(`gh_token_${authUser.uid}`, accessToken);
+      // Keep the token in React state only -- do not write to Web Storage.
+      setGhAccessToken(accessToken);
 
       const userDocRef = doc(db, "users", authUser.uid);
       const docSnap = await getDoc(userDocRef);
@@ -146,13 +152,11 @@ export const AuthProvider = ({ children }) => {
   const logout = async () => {
     setLoading(true);
     try {
-      if (user) {
-        sessionStorage.removeItem(`gh_token_${user.uid}`);
-      }
       await signOutUser();
       setUser(null);
       setUserData(null);
       setIsOnboarding(false);
+      setGhAccessToken(null);
     } catch (error) {
       console.error("Logout failure:", error);
     } finally {
@@ -160,9 +164,13 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
-  // Securely fetches GitHub stats on the client once using the transient OAuth token
+  // Fetches GitHub stats once after login using the in-memory OAuth token.
+  // The token is no longer read from sessionStorage -- it comes from the
+  // ghAccessToken state variable which is populated on login and cleared on
+  // logout. This prevents any JavaScript on the page from reading the token
+  // via sessionStorage.getItem().
   const fetchGitHubStats = async (uid, username) => {
-    const token = sessionStorage.getItem(`gh_token_${uid}`);
+    const token = ghAccessToken;
     const headers = token ? { Authorization: `token ${token}` } : {};
 
     try {


### PR DESCRIPTION
## Description

`AuthContext.jsx` stored the GitHub OAuth access token in `sessionStorage`:

```js
sessionStorage.setItem(`gh_token_${authUser.uid}`, accessToken);
```

`sessionStorage` is accessible to any JavaScript running on the page. An XSS injection (via a third-party script, unsanitised user content, or a compromised dependency) can read it with a single `sessionStorage.getItem()` call, exfiltrating the token and giving the attacker the same GitHub API access as the victim for the token's lifetime. The comment in the code describing this as "securely (non-persistent across tabs for security)" was inaccurate: sessionStorage is still readable by all scripts on the same origin.

## Root Cause

The token was written to `sessionStorage` to allow `fetchGitHubStats` to retrieve it by key. The solution is to keep it in React state, which is not accessible via the DOM Storage API.

## Related Issue

Closes #80

## Type of Change

- [x] Bug fix / Security fix

## Changes Made

- `src/context/AuthContext.jsx`:
  - Added `ghAccessToken` state variable (`useState(null)`).
  - `setGhAccessToken(accessToken)` replaces `sessionStorage.setItem()` on login.
  - `setGhAccessToken(null)` replaces `sessionStorage.removeItem()` on logout.
  - `fetchGitHubStats` reads from `ghAccessToken` state instead of `sessionStorage.getItem()`.

The token is now only in React component memory and is never written to any Web Storage API.

## Screenshots or Demo

Not applicable.

## Testing Done

1. Log in with GitHub OAuth. Confirm GitHub stats are fetched and displayed correctly.
2. Log out. Confirm `ghAccessToken` is cleared (stats no longer available without re-login).
3. Confirm no `sessionStorage` entries are created for the OAuth token after login.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue

Could you please add the appropriate NSoC'26 label to this PR? It helps with tracking and scoring under NSoC 2026. Thank you!