### PR TITLE
fix(security): prevent duplicate UID entries in referrals usedBy array

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -90,9 +90,15 @@ service cloud.firestore {
       // Let the owner create their own referrals index document
       allow create: if isOwner(uid);
 
-      // Allow either the owner to write, OR a referred user to atomically append their UID to 'usedBy' and increment totalEarned by 100
+      // Allow either the owner to write, OR a referred user to atomically append their UID to
+      // 'usedBy' and increment totalEarned by 100.
+      // The uniqueness guard (!(request.auth.uid in resource.data.usedBy)) ensures that the same
+      // caller cannot append their UID a second time. Without it, a user could submit
+      // ["user_A", "user_A"] and satisfy both the size-growth check and the last-element check,
+      // farming unlimited referral points against the same referrer.
       allow update: if isOwner(uid) || (
         isAuthenticated()
+        && !(request.auth.uid in resource.data.usedBy)
         && request.resource.data.usedBy.size() == resource.data.usedBy.size() + 1
         && request.resource.data.usedBy[resource.data.usedBy.size()] == request.auth.uid
         && request.resource.data.totalEarned == resource.data.totalEarned + 100


### PR DESCRIPTION
## Related Issue

Closes #83

## Problem

The `referrals/{uid}` update rule in `firestore.rules` checked three conditions for a non-owner write:

```js
&& request.resource.data.usedBy.size() == resource.data.usedBy.size() + 1
&& request.resource.data.usedBy[resource.data.usedBy.size()] == request.auth.uid
&& request.resource.data.totalEarned == resource.data.totalEarned + 100
```

None of these conditions verified that the caller's UID was **not already present** in `usedBy`. Because Firestore arrays permit duplicate values, a user who had already redeemed a referral (`usedBy = ["user_A"]`) could submit a second write with `usedBy = ["user_A", "user_A"]`:

- `size()` grows from 1 to 2 — condition 1 satisfied.
- `usedBy[1] == request.auth.uid` — condition 2 satisfied.
- `totalEarned` incremented by 100 — condition 3 satisfied.

The write was accepted, adding another 100 referral points to the referrer. This could be repeated indefinitely.

## Fix

Added `!(request.auth.uid in resource.data.usedBy)` as the first condition of the non-owner branch:

```js
allow update: if isOwner(uid) || (
  isAuthenticated()
  && !(request.auth.uid in resource.data.usedBy)   // added: block duplicate appends
  && request.resource.data.usedBy.size() == resource.data.usedBy.size() + 1
  && request.resource.data.usedBy[resource.data.usedBy.size()] == request.auth.uid
  && request.resource.data.totalEarned == resource.data.totalEarned + 100
);
```

The `in` operator on a Firestore array evaluates server-side atomically. Once a UID exists in `usedBy`, every subsequent attempt by the same caller is rejected at the rules layer with no way to circumvent it from the client.

## Files Changed

| File | Change |
|---|---|
| `firestore.rules` | Add `!(request.auth.uid in resource.data.usedBy)` guard to the `referrals/{uid}` update rule |

## Testing

| Scenario | Before | After |
|---|---|---|
| First referral redemption by user A | Allowed | Allowed |
| Second redemption by same user A | Allowed (exploit) | Denied (403) |
| Owner updating their own referral doc | Allowed | Allowed |

---

Could you please add the appropriate labels to this PR when you get a chance? It would help with tracking. Thank you!