### PR TITLE
fix(security): require verified referral relationship in RULE 3 of users/{uid}

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -73,15 +73,24 @@ service cloud.firestore {
           )
         );
 
-      // RULE 3: Referrer update - Allow another user to atomically increment a referrer's referralPoints by exactly 100 points
-      // as part of the onboarding referral transaction.
-      allow update: if isAuthenticated() 
-        && request.auth.uid != uid // must be the referred user performing the write
+      // RULE 3: Referrer update - Allow the referred user to atomically increment a referrer's
+      // referralPoints by exactly 100 points as part of the onboarding referral transaction.
+      // Two additional guards close the exploit described in issue #81:
+      //   1. exists(...) confirms the referrals index document for the target user exists,
+      //      which is only created when the referrer generates a referral code.
+      //   2. request.auth.uid in get(...).data.usedBy confirms the caller is already recorded
+      //      in the referrer's usedBy list, meaning they legitimately redeemed the referral
+      //      code before this point update fires. This prevents any arbitrary authenticated
+      //      user from granting unlimited referral points to any other user.
+      allow update: if isAuthenticated()
+        && request.auth.uid != uid
         && request.resource.data.points.referralPoints == resource.data.points.referralPoints + 100
         && request.resource.data.points.totalPoints == resource.data.points.totalPoints + 100
         && request.resource.data.points.gitRankPoints == resource.data.points.gitRankPoints
         && request.resource.data.points.codingVersePoints == resource.data.points.codingVersePoints
-        && request.resource.data.points.streakPoints == resource.data.points.streakPoints;
+        && request.resource.data.points.streakPoints == resource.data.points.streakPoints
+        && exists(/databases/$(database)/documents/referrals/$(uid))
+        && request.auth.uid in get(/databases/$(database)/documents/referrals/$(uid)).data.usedBy;
     }
 
     match /referrals/{uid} {


### PR DESCRIPTION
## Related Issue

Closes #81

## Problem

RULE 3 in `firestore.rules` allowed any authenticated user to write to **any** other user's document as long as they incremented `referralPoints` by exactly 100 and left all other point fields unchanged:

```js
allow update: if isAuthenticated()
  && request.auth.uid != uid   // only prevents self-referral
  && request.resource.data.points.referralPoints == resource.data.points.referralPoints + 100
  && ...                       // no relationship check
```

The rule did not verify that:
- A real referral relationship existed between the caller and the target.
- The referral had already been recorded in the referrals collection.

Any logged-in user could identify any other user's UID via the public leaderboard and make repeated writes that each satisfied RULE 3, inflating the target's referral points indefinitely.

## Fix

Added two cross-collection server-side guards to RULE 3:

```js
&& exists(/databases/$(database)/documents/referrals/$(uid))
&& request.auth.uid in get(/databases/$(database)/documents/referrals/$(uid)).data.usedBy
```

| Guard | Purpose |
|---|---|
| `exists(referrals/$(uid))` | Confirms the referrer has a referrals index document (created only on code generation) |
| `request.auth.uid in ...usedBy` | Confirms the caller already redeemed the referral, which appended their UID to `usedBy` |

Together they ensure the point update can only follow a legitimate, recorded referral redemption. Both checks are evaluated atomically server-side and cannot be bypassed from the client.

## Files Changed

| File | Change |
|---|---|
| `firestore.rules` | Add `exists` and `in usedBy` cross-collection guards to RULE 3 |

## Testing

| Scenario | Before | After |
|---|---|---|
| Caller not in target's usedBy | Allowed (exploit) | Denied |
| Caller legitimately in usedBy | Allowed | Allowed |
| Self-referral (caller == uid) | Denied | Denied |

---

Could you please add the appropriate labels to this PR when you get a chance? It would help with tracking. Thank you!