### PR TITLE
perf: shift leaderboard sorting to firestore query to improve client performance

### DIFF
--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { Search, Filter, Star, Trophy, RefreshCw, GitCommit, Calendar, BookOpen, AlertCircle, CheckCircle2 } from "lucide-react";
-import { collection, query, where, onSnapshot, doc, runTransaction } from "firebase/firestore";
+import { collection, query, where, onSnapshot, doc, runTransaction, orderBy, limit } from "firebase/firestore";
 import { useSearchParams } from "react-router-dom";
 import { db } from "../lib/firebase";
 import { useAuth } from "../context/AuthContext";
@@ -33,7 +33,6 @@ export const GitRank = () => {
 
   // 1. Real-time Leaderboard Listener
   useEffect(() => {
-    // Only listen if user is logged in (due to read rules requiring authentication)
     if (!user) {
       const timer = setTimeout(() => {
         setLoadingUsers(false);
@@ -43,7 +42,9 @@ export const GitRank = () => {
 
     const q = query(
       collection(db, "users"),
-      where("onboardingStatus", "==", "complete")
+      where("onboardingStatus", "==", "complete"),
+      orderBy("points.totalPoints", "desc"),
+      limit(100) 
     );
 
     const unsubscribe = onSnapshot(
@@ -54,10 +55,7 @@ export const GitRank = () => {
           users.push(doc.data());
         });
 
-        // Sort by totalPoints descending
-        users.sort((a, b) => (b.points?.totalPoints || 0) - (a.points?.totalPoints || 0));
 
-        // Assign ranks
         const ranked = users.map((u, i) => ({
           ...u,
           rank: i + 1
@@ -120,7 +118,6 @@ export const GitRank = () => {
       const ghStats = await fetchGitHubStats(user.uid, userData.githubUsername);
       const userRef = doc(db, "users", user.uid);
 
-      // Execute atomic transaction to prevent write-stomping points race condition
       await runTransaction(db, async (transaction) => {
         const userDoc = await transaction.get(userRef);
         if (!userDoc.exists()) {
@@ -193,7 +190,6 @@ export const GitRank = () => {
     }).reverse();
 
     if (!events.length) {
-      // Mock pattern if events are empty so user sees how it looks
       return [
         { label: "Wk 1", commits: 2, prs: 0, reviews: 0 },
         { label: "Wk 2", commits: 6, prs: 1, reviews: 0 },


### PR DESCRIPTION
### Description
This PR addresses the performance bottleneck caused by fetching all users and sorting them on the client side for the leaderboard. 

**Key Changes:**
* Modified the Firebase query in `GitRank.jsx` to include `orderBy("points.totalPoints", "desc")`.
* Added a `limit(100)` to prevent fetching excessive documents and crashing the browser as the user base scales.
* Removed the manual `users.sort()` operation from the `onSnapshot` callback, relying entirely on the indexed database results.
* Added instructions to create the necessary Composite Index in Firestore.

Fixes #106