### PR TITLE
fix(onboarding): abort write when referral code uniqueness check exhausts all attempts

### DIFF
--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -193,6 +193,12 @@ export const Onboarding = () => {
         }
       }
 
+      if (!codeUnique) {
+        setError("Could not generate a unique referral code after multiple attempts. Please try again.");
+        setIsLoading(false);
+        return;
+      }
+
       // Referral variables
       let referrerUid = null;
       let referrerCodeClean = referralCode.trim().toUpperCase();


### PR DESCRIPTION
## Summary

- After the 10-attempt while loop for referral code uniqueness exits, the code proceeded to write to Firestore even if all 10 attempts collided and a unique code was never found
- Added a guard after the loop: if \`codeUnique\` is still false, show an error and return early to prevent writing a duplicate referral code to the users collection

## Test plan

- [ ] In a local emulator, seed 26^6 = over 300 million records to force collision (or mock \`getDocs\` to always return non-empty)
- [ ] Confirm the form shows the error message and does not navigate to the dashboard
- [ ] Normal flow: verify onboarding still completes successfully when a unique code is generated on the first attempt

Closes #125