### PR TITLE
fix(friends): remove fabricated mutualFriends and online fields

### DIFF
--- a/src/services/friendsService.js
+++ b/src/services/friendsService.js
@@ -15,8 +15,8 @@ export const fetchDevelopers = async () => {
         role: data.role || "Developer",
         bio: data.bio || "Building awesome projects on RankerHub.",
         tags: data.skills || ["Developer"],
-        mutualFriends: Math.floor(Math.random() * 10), 
-        online: Math.random() > 0.5, 
+        mutualFriends: 0,
+        online: false,
         activity: "Recently joined RankerHub"
       };
     });


### PR DESCRIPTION
## Summary

- \`fetchDevelopers\` was assigning \`Math.random()\`-derived values to \`mutualFriends\` and \`online\`, generating different numbers on every render and misrepresenting real user data to the UI
- Replaced with deterministic zero values: \`mutualFriends: 0\` and \`online: false\`
- These fields will remain at their default until a real backend data source is implemented

## Test plan

- [ ] Open the Friends page and confirm developer cards no longer show fluctuating mutual friends counts or random online badges
- [ ] Confirm \`mutualFriends\` always shows 0 and \`online\` always shows false until real data is wired

Closes #131