### PR TITLE
fix(friends): remove mock follower ID seeding from useEffect

### DIFF
--- a/src/pages/Friends.jsx
+++ b/src/pages/Friends.jsx
@@ -41,11 +41,6 @@ export const Friends = () => {
         // Remove the current logged-in user from the list
         const filteredDevs = fetchedDevs.filter(dev => dev.id !== currentUser?.uid);
         setDevelopers(filteredDevs);
-        
-        // Mock a couple of followers for UI testing (remove once #105 backend logic is done)
-        if (filteredDevs.length > 2) {
-          setFollowerIds([filteredDevs[0].id, filteredDevs[1].id]);
-        }
       } catch (error) {
         console.error("Failed to load developers", error);
       } finally {


### PR DESCRIPTION
## Summary

- The \`useEffect\` in \`Friends.jsx\` was calling \`setFollowerIds([filteredDevs[0].id, filteredDevs[1].id])\` after fetching developers, which caused the Followers tab to always show 2 entries for any user seeing 3+ developers
- Removed the mock block entirely so \`followerIds\` initializes as \`[]\` and stays empty until a real follow backend is implemented

## Test plan

- [ ] Open the Friends page and navigate to the Followers tab - it should show 0 followers
- [ ] Verify the Friends and Following tabs are unaffected
- [ ] Confirm the Followers count card shows 0

Closes #132