### PR TITLE
fix: persist follow status by integrating firestore follows collection (#105)

### DIFF
--- a/src/pages/Friends.jsx
+++ b/src/pages/Friends.jsx
@@ -9,7 +9,9 @@ import { useAuth } from "../context/AuthContext";
 import {
   fetchDevelopers,
   hydrateConnections,
-  toggleFollowStatus
+  toggleFollowStatus,
+  subscribeToFollowing,
+  subscribeToFollowers
 } from "../services/friendsService";
 
 const tabs = [
@@ -35,17 +37,14 @@ export const Friends = () => {
   const [followerIds, setFollowerIds] = useState([]);
 
   useEffect(() => {
+    let unsubFollowing = () => {};
+    let unsubFollowers = () => {};
+
     const loadDevelopers = async () => {
       try {
         const fetchedDevs = await fetchDevelopers();
-        // Remove the current logged-in user from the list
         const filteredDevs = fetchedDevs.filter(dev => dev.id !== currentUser?.uid);
         setDevelopers(filteredDevs);
-        
-        // Mock a couple of followers for UI testing (remove once #105 backend logic is done)
-        if (filteredDevs.length > 2) {
-          setFollowerIds([filteredDevs[0].id, filteredDevs[1].id]);
-        }
       } catch (error) {
         console.error("Failed to load developers", error);
       } finally {
@@ -53,7 +52,23 @@ export const Friends = () => {
       }
     };
     
-    loadDevelopers();
+    if (currentUser?.uid) {
+      loadDevelopers();
+      
+      // Setup Real-time Firebase Listeners
+      unsubFollowing = subscribeToFollowing(currentUser.uid, (ids) => {
+        setFollowingIds(ids);
+      });
+      
+      unsubFollowers = subscribeToFollowers(currentUser.uid, (ids) => {
+        setFollowerIds(ids);
+      });
+    }
+
+    return () => {
+      unsubFollowing();
+      unsubFollowers();
+    };
   }, [currentUser]);
 
   const connections = useMemo(
@@ -68,8 +83,10 @@ export const Friends = () => {
     following: "Developers whose rankings, activity, and learning notes you follow."
   };
 
-  const handleToggleFollow = (developerId) => {
-    setFollowingIds((currentIds) => toggleFollowStatus(currentIds, developerId));
+  const handleToggleFollow = async (developerId) => {
+    const isFollowing = followingIds.includes(developerId);
+    // Directly mutate Firebase. The onSnapshot listener will automatically update the UI!
+    await toggleFollowStatus(currentUser.uid, developerId, isFollowing);
   };
 
   if (loading) {
@@ -196,15 +213,15 @@ export const Friends = () => {
             ))}
           </div>
 
-          <Card className="p-5 bg-gradient-to-br from-cyan-500/10 to-violet-500/10 border-cyan-500/20">
+          <Card className="p-5 bg-gradient-to-br from-emerald-500/10 to-teal-500/10 border-emerald-500/20">
             <div className="flex items-start gap-3">
-              <div className="w-10 h-10 rounded-2xl bg-white/70 dark:bg-slate-950/40 flex items-center justify-center text-cyan-600 dark:text-cyan-400">
+              <div className="w-10 h-10 rounded-2xl bg-white/70 dark:bg-slate-950/40 flex items-center justify-center text-emerald-600 dark:text-emerald-400">
                 <Activity className="w-5 h-5" />
               </div>
               <div>
-                <h3 className="font-black text-slate-900 dark:text-white my-0">Connection insights</h3>
+                <h3 className="font-black text-slate-900 dark:text-white my-0">Database Connected</h3>
                 <p className="text-sm text-slate-500 dark:text-slate-400 font-medium mt-1">
-                  Follow state is mocked locally today and isolated in a service so API integration can replace it later.
+                  Follow state is now persisting via real-time Firestore listeners. Refresh to see your friends!
                 </p>
               </div>
             </div>

--- a/src/services/friendsService.js
+++ b/src/services/friendsService.js
@@ -1,4 +1,4 @@
-import { collection, getDocs } from "firebase/firestore";
+import { collection, getDocs, doc, setDoc, deleteDoc, onSnapshot, query, where } from "firebase/firestore";
 import { db } from "../lib/firebase";
 
 // Asynchronously fetch real users from Firebase
@@ -26,15 +26,50 @@ export const fetchDevelopers = async () => {
   }
 };
 
-export const toggleFollowStatus = (followingIds, developerId) => {
-  if (followingIds.includes(developerId)) {
-    return followingIds.filter((id) => id !== developerId);
+// Real-time listener for users the current user is following
+export const subscribeToFollowing = (currentUserId, callback) => {
+  if (!currentUserId) return () => {};
+  const q = query(collection(db, "follows"), where("followerId", "==", currentUserId));
+  return onSnapshot(q, (snapshot) => {
+    const followingIds = snapshot.docs.map(doc => doc.data().followedId);
+    callback(followingIds);
+  });
+};
+
+// Real-time listener for users following the current user
+export const subscribeToFollowers = (currentUserId, callback) => {
+  if (!currentUserId) return () => {};
+  const q = query(collection(db, "follows"), where("followedId", "==", currentUserId));
+  return onSnapshot(q, (snapshot) => {
+    const followerIds = snapshot.docs.map(doc => doc.data().followerId);
+    callback(followerIds);
+  });
+};
+
+// Toggle logic with Firestore
+export const toggleFollowStatus = async (currentUserId, developerId, isFollowing) => {
+  if (!currentUserId || !developerId) return;
+  const followDocId = `${currentUserId}_${developerId}`;
+  const followRef = doc(db, "follows", followDocId);
+
+  try {
+    if (isFollowing) {
+      // Unfollow
+      await deleteDoc(followRef);
+    } else {
+      // Follow
+      await setDoc(followRef, {
+        followerId: currentUserId,
+        followedId: developerId,
+        createdAt: new Date().toISOString()
+      });
+    }
+  } catch (error) {
+    console.error("Error toggling follow status:", error);
   }
-  return [...followingIds, developerId];
 };
 
 export const hydrateConnections = (developers, followingIds, followerIds) => {
-  // Defensive check in case developers is undefined during loading
   if (!developers) return { friends: [], followers: [], following: [], suggested: [] };
 
   const following = developers.filter((developer) => followingIds.includes(developer.id));


### PR DESCRIPTION
### Description
Fixes #105 by replacing the volatile in-memory follow array with a fully persistent Firestore integration. Follow, unfollow, and mutual friend ("Friends") states are now tracked and synced in real-time.

**Key Changes:**
* **Database Updates (`friendsService.js`):**
  * Created `toggleFollowStatus` to interact directly with the `follows` collection using atomic `setDoc` and `deleteDoc` operations.
  * Added `subscribeToFollowing` and `subscribeToFollowers` methods leveraging `onSnapshot` queries to actively listen for remote follow changes.
* **Component Reactivity (`Friends.jsx`):**
  * Integrated database listeners within the main `useEffect` block, dynamically updating UI states (`followingIds` & `followerIds`) without requiring manual re-fetching.
  * Removed hardcoded mock follower IDs.
  * Updated the insights card copy to reflect active database connectivity.

Fixes #105