### PR TITLE
fix: replace inline bullet with JSX-safe separator in search results (#164)

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -80,7 +80,7 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
 
   return (
     <nav className="sticky top-0 z-30 h-16 border-b border-slate-200/50 dark:border-slate-800/50 bg-white/70 dark:bg-slate-950/70 backdrop-blur-md shadow-sm transition-all duration-300 px-4 md:px-6 flex items-center justify-between relative">
-      
+
       {/* Mobile Search Overlay */}
       <AnimatePresence>
         {isMobileSearchOpen && (
@@ -100,7 +100,7 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
                 autoFocus
                 className="w-full pl-10 pr-4 py-2 text-sm rounded-xl border border-slate-200/60 dark:border-slate-800/60 bg-slate-50 dark:bg-slate-900 focus:outline-none focus:ring-2 focus:ring-violet-500/20 focus:border-violet-500 dark:text-white transition-all"
               />
-              
+
               {/* Mobile Search Results Dropdown */}
               <AnimatePresence>
                 {showSearchResults && searchResults.length > 0 && (
@@ -132,7 +132,7 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
                               {user.name}
                             </p>
                             <p className="text-xs text-slate-500 dark:text-slate-400 truncate">
-                              @{user.username} • {user.language}
+                              @{user.username}{" • "}{user.language}
                             </p>
                           </div>
                         </button>
@@ -204,7 +204,7 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
           onChange={handleSearchChange}
           className="w-full pl-10 pr-4 py-2 text-sm rounded-xl border border-slate-200/60 dark:border-slate-800/60 bg-white/40 dark:bg-slate-900/40 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-violet-500/20 focus:border-violet-500 dark:text-white transition-all placeholder:text-slate-400 dark:placeholder:text-slate-500"
         />
-        
+
         {/* Search Results Dropdown */}
         <AnimatePresence>
           {showSearchResults && searchResults.length > 0 && (
@@ -233,7 +233,8 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
                         {user.name}
                       </p>
                       <p className="text-xs text-slate-500 dark:text-slate-400 truncate">
-                        @{user.username} • {user.language} • #{user.rank}
+
+                        @{user.username}{" • "}{user.language}{" • "}#{user.rank}
                       </p>
                     </div>
                     <div className="text-right">
@@ -263,7 +264,7 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
       {/* Right side: Actions, Theme, Notifications, Profile */}
       <div className="flex items-center gap-3">
         {/* Search toggle for small screens */}
-        <button 
+        <button
           onClick={() => setIsMobileSearchOpen(true)}
           className="md:hidden p-2 rounded-xl text-slate-600 dark:text-slate-400 hover:bg-slate-100/50 dark:hover:bg-slate-800/50 transition cursor-pointer"
         >
@@ -324,9 +325,8 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
                     notifications.map((n) => (
                       <div
                         key={n.id}
-                        className={`p-4 transition-colors relative group flex items-start gap-3 hover:bg-slate-50 dark:hover:bg-slate-800 ${
-                          !n.read ? "bg-violet-50/20 dark:bg-violet-500/5" : ""
-                        }`}
+                        className={`p-4 transition-colors relative group flex items-start gap-3 hover:bg-slate-50 dark:hover:bg-slate-800 ${!n.read ? "bg-violet-50/20 dark:bg-violet-500/5" : ""
+                          }`}
                       >
                         {/* Red/Green status light */}
                         {!n.read && (


### PR DESCRIPTION
## Description
Replaced raw inline bullet character `•` with JSX-safe `{" • "}` 
in search result dropdowns to prevent potential Unicode rendering 
issues (broken `â€¢` characters) across different environments 
and encodings.

## Related Issue
Fixes #164

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
[Add screenshot of search dropdown showing correct bullet rendering]

## Testing Done
- [x] Visual verification on local dev server (`http://localhost:5173`)
- [x] Verified bullet `•` renders correctly in both mobile and desktop search dropdowns
- [x] No console errors or warnings

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **GSSoC 2026** and **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the Contributing Guidelines and Code of Conduct.