### PR TITLE
fix: persist longestStreak to Firestore and add security rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,6 +19,18 @@ service cloud.firestore {
       return affected.hasOnly(profileFields);
     }
 
+    // Helper: Check if update is a legitimate streak check-in write from checkAndUpdateStreak.
+    // Whitelists the exact fields touched: streak, longestStreak, lastLogin,
+    // points.streakPoints, points.totalPoints. longestStreak must never decrease.
+    function isStreakUpdate() {
+      let affected = request.resource.data.diff(resource.data).affectedKeys();
+      let streakFields = ['streak', 'longestStreak', 'lastLogin', 'points'];
+      return affected.hasOnly(streakFields)
+        && request.resource.data.longestStreak >= resource.data.longestStreak
+        && request.resource.data.streak >= 0
+        && request.resource.data.points.streakPoints >= resource.data.points.streakPoints;
+    }
+
     match /users/{uid} {
       // Leaderboard requires public access to view user standings
       allow read: if true;
@@ -33,7 +45,11 @@ service cloud.firestore {
       // This bypasses the strict onboarding/points rules for profile information updates only
       allow update: if isOwner(uid) && isOnlyProfileUpdate();
 
-      // RULE 2: Original strict rules for onboarding and points updates
+      // RULE 2: Allow streak check-in writes that touch only streak-related fields.
+      // longestStreak is enforced as monotonically non-decreasing by the helper.
+      allow update: if isOwner(uid) && isStreakUpdate();
+
+      // RULE 3: Original strict rules for onboarding and points updates
       allow update: if isOwner(uid) 
         // 1. If they were already onboarded (onboardingStatus == "complete"), they cannot change immutable onboarding fields
         && (resource.data.onboardingStatus != "complete" || (

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -47,14 +47,17 @@ const checkAndUpdateStreak = async (data, docRef) => {
                            (data.points?.codingVersePoints || 0) + 
                            newStreakPoints;
                            
+    const newLongestStreak = Math.max(data.longestStreak || 0, newStreak);
+
     try {
       await updateDoc(docRef, {
         streak: newStreak,
+        longestStreak: newLongestStreak,
         lastLogin: now.toISOString(),
         "points.streakPoints": newStreakPoints,
         "points.totalPoints": newTotalPoints
       });
-      console.log("Streak updated successfully. New Streak:", newStreak);
+      console.log("Streak updated successfully. New Streak:", newStreak, "| Longest:", newLongestStreak);
     } catch (err) {
       console.error("Failed to update streak:", err);
     }
@@ -151,6 +154,7 @@ export const AuthProvider = ({ children }) => {
           privateRepoSyncEnabled: requestRepoScope,
           city: "",
           streak: 0,
+          longestStreak: 0,
           lastLogin: new Date().toISOString(),
           createdAt: new Date().toISOString(),
           points: {


### PR DESCRIPTION
I Worked on this under NSOC'26
closes #206 
Implementation Plan:

Schema Update: Add longestStreak: 0 to the Firestore new user document schema so the field exists in Firestore from the moment of registration.

Streak Logic Enhancement in AuthContext.jsx:
Modify checkAndUpdateStreak to compute longestStreak using Math.max and write it to Firestore in the same atomic updateDoc call:
```
const newLongestStreak = Math.max(data.longestStreak || 0, newStreak);
await updateDoc(docRef, {
  streak: newStreak,
  longestStreak: newLongestStreak,
  lastLogin: now.toISOString(),
  "points.streakPoints": newStreakPoints,
  "points.totalPoints": newTotalPoints
});
```

Backend Security Rules in firestore.rules:
```
Add isStreakUpdate() helper to explicitly whitelist streak fields and wire it as a new allow update rule:
function isStreakUpdate() {
  let streakFields = ['streak', 'longestStreak', 'lastLogin', 'points'];
  return affected.hasOnly(streakFields)
    && request.resource.data.longestStreak >= resource.data.longestStreak;
}
allow update: if isOwner(uid) && isStreakUpdate();
```

Dashboard Integration:
StreakCard.jsx already read userData?.longestStreak from user context — no changes needed. Once Firestore is updated, the onSnapshot listener automatically re-renders the card with the live value.

Edge Cases:

- Handle streak resets — streak drops to 1 but Math.max preserves longestStreak at the old record
- Existing users without longestStreak field — data.longestStreak || 0 fallback ensures self-healing on next login-day transition
- Prevent malicious writes — Firestore rule enforces longestStreak >= resource.data.longestStreak at the server level