### PR TITLE
fix: implement robust route check for onboarding status and HashRouter URL redirect (Resolves #217)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { HashRouter } from "react-router-dom";
 import { ThemeProvider } from "./context/ThemeContext";
 import { AuthProvider } from "./context/AuthContext";
@@ -9,6 +9,14 @@ import RateLimitBanner from "./components/ui/RateLimitBanner";
 import Preloader from "./components/ui/Preloader";
 
 function App() {
+  // Convert pathname to hash router format to prevent routing bugs
+  useEffect(() => {
+    const path = window.location.pathname;
+    if (path !== '/' && path !== '/index.html') {
+      window.location.replace('/#' + path + window.location.hash);
+    }
+  }, []);
+
   return (
     <ErrorBoundary>
       <ThemeProvider>

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -53,7 +53,7 @@ const ProtectedRoute = ({ children }) => {
 
 // Route Guard: Access allowed ONLY if authenticated AND onboarding is incomplete
 const OnboardingRoute = ({ children }) => {
-  const { user, loading, isOnboarding } = useAuth();
+  const { user, loading, userData, isOnboarding } = useAuth();
 
   if (loading) {
     return <LoadingScreen message="Loading Onboarding portal..." />;
@@ -63,7 +63,9 @@ const OnboardingRoute = ({ children }) => {
     return <Navigate to="/login" replace />;
   }
 
-  if (!isOnboarding) {
+  // Strict guard: if the user's data explicitly says they are complete, OR if isOnboarding is false, redirect.
+  // We only allow access if they are explicitly incomplete.
+  if (userData?.onboardingStatus === "complete" || !isOnboarding || (userData && userData.onboardingStatus !== "incomplete")) {
     return <Navigate to="/dashboard" replace />;
   }
 


### PR DESCRIPTION

**Description:**

**What does this PR do?**
This PR resolves an issue where a user who had already fully onboarded could manually navigate to the `/onboarding` route by typing it into the browser's URL bar, allowing them to re-submit their onboarding form and reset their referral code and initial scores.

**How was it fixed?**
This PR implements a two-part fix to address both the routing logic and the visual URL bugs:
1. **Strict Route Guard:** Updated the `OnboardingRoute` in `src/routes/AppRoutes.jsx` to explicitly check if `userData.onboardingStatus === "complete"`. If a user is already fully onboarded, the guard now instantly catches this and redirects them to the `/dashboard`.
2. **HashRouter Path Interceptor:** Added a `useEffect` inside `src/App.jsx` that detects when a user manually types a path like `localhost:5173/onboarding` (without the hash) and forces a hard `window.location.replace` to properly map them to the hash route (`/#/onboarding`). This ensures React Router correctly processes the URL and triggers the route guards, preventing users from getting stuck with misleading URLs while viewing the Home Page or Dashboard.

**Acceptance Criteria Met:**
- [x] Re-navigating to `/onboarding` strictly redirects fully onboarded users to `/dashboard`.
- [x] Typing `/onboarding` manually correctly evaluates the route using the HashRouter instead of ignoring it.

**Visual Proof:**

https://github.com/user-attachments/assets/af84b7df-edef-49de-89ba-4a2d20cdc50a


**Closes: #217** 