### PR TITLE
fix: fetch real GitHub contribution data for heatmap instead of Math.random() (#185)

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -12,54 +12,50 @@ import StreakCard from "../components/dashboard/StreakCard";
 import RankPreview from "../components/dashboard/RankPreview";
 import ActivityFeed from "../components/dashboard/ActivityFeed";
 
-
-// Generate dummy data for GitHub contribution graph mockup
 const heatmapColors = [
-  "bg-slate-100 dark:bg-slate-800/40", // 0 contributions
-  "bg-violet-500/10 dark:bg-violet-500/10", // low
-  "bg-violet-500/30 dark:bg-violet-500/30", // medium-low
-  "bg-violet-500/60 dark:bg-violet-500/50", // medium-high
-  "bg-violet-600 dark:bg-violet-600" // high
+  "bg-slate-100 dark:bg-slate-800/40",
+  "bg-violet-500/10 dark:bg-violet-500/10",
+  "bg-violet-500/30 dark:bg-violet-500/30",
+  "bg-violet-500/60 dark:bg-violet-500/50",
+  "bg-violet-600 dark:bg-violet-600"
 ];
 
-const [heatmapCells, setHeatmapCells] = useState(
-  Array.from({ length: 168 }, () => 0)
-);
-
-useEffect(() => {
-  const fetchHeatmap = async () => {
-    const username = userData?.githubUsername;
-    if (!username) return;
-    try {
-      const res = await fetch(
-        `https://github-contributions-api.jogruber.de/v4/${username}?y=last`
-      );
-      const data = await res.json();
-      const contributions = data.contributions || [];
-      const last168 = contributions.slice(-168);
-      const cells = last168.map((day) => {
-        const c = day.count;
-        if (c === 0) return 0;
-        if (c <= 2) return 1;
-        if (c <= 5) return 2;
-        if (c <= 9) return 3;
-        return 4;
-      });
-      setHeatmapCells(cells);
-    } catch (err) {
-      console.error("Heatmap fetch error:", err);
-    }
-  };
-  fetchHeatmap();
-}, [userData?.githubUsername]);
 export const Dashboard = () => {
   const { userData } = useAuth();
   const [rank, setRank] = useState("Loading...");
+  const [heatmapCells, setHeatmapCells] = useState(
+    Array.from({ length: 168 }, () => 0)
+  );
 
-  // Optimized rank count query
+  useEffect(() => {
+    const fetchHeatmap = async () => {
+      const username = userData?.githubUsername;
+      if (!username) return;
+      try {
+        const res = await fetch(
+          `https://github-contributions-api.jogruber.de/v4/${username}?y=last`
+        );
+        const data = await res.json();
+        const contributions = data.contributions || [];
+        const last168 = contributions.slice(-168);
+        const cells = last168.map((day) => {
+          const c = day.count;
+          if (c === 0) return 0;
+          if (c <= 2) return 1;
+          if (c <= 5) return 2;
+          if (c <= 9) return 3;
+          return 4;
+        });
+        setHeatmapCells(cells);
+      } catch (err) {
+        console.error("Heatmap fetch error:", err);
+      }
+    };
+    fetchHeatmap();
+  }, [userData?.githubUsername]);
+
   useEffect(() => {
     if (!userData || !userData.points) return;
-
     const fetchRank = async () => {
       try {
         const q = query(
@@ -74,7 +70,6 @@ export const Dashboard = () => {
         setRank("#N/A");
       }
     };
-
     fetchRank();
   }, [userData]);
 
@@ -102,32 +97,24 @@ export const Dashboard = () => {
 
   return (
     <div className="space-y-6">
-
-      {/* Page Header */}
       <SectionHeader
         title="Overview Dashboard"
         subtitle="Track your progress, achievements, and rankings in real-time."
         badge="Live Metrics"
       />
 
-      {/* Hero Welcome banner with Trophy */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-
-        {/* Welcome & Trophy (Takes 2 cols) */}
         <Card className="lg:col-span-2 flex flex-col sm:flex-row items-center justify-between gap-6 p-8 bg-gradient-to-br from-violet-600/10 via-indigo-600/10 to-blue-600/10 border-violet-500/15">
           <div className="space-y-4 text-center sm:text-left">
             <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold bg-violet-600/20 text-violet-700 dark:text-violet-400">
               <Award className="w-4 h-4 animate-bounce" /> Level {devLevel} Developer
             </div>
-
             <h2 className="text-2xl md:text-3xl font-black text-slate-900 dark:text-white leading-tight my-0">
               Welcome back, {userData?.name || "Developer"}!
             </h2>
-
             <p className="text-sm md:text-base text-slate-500 dark:text-slate-400 max-w-md font-medium">
               You are currently ranked <span className="font-bold text-slate-800 dark:text-white">{rank}</span> globally. Complete daily arena challenges to boost your rank!
             </p>
-
             <div className="pt-2 flex items-center justify-center sm:justify-start gap-4">
               <div className="w-full max-w-[200px] h-2 bg-slate-200 dark:bg-slate-800 rounded-full overflow-hidden">
                 <div
@@ -138,13 +125,11 @@ export const Dashboard = () => {
               <span className="text-xs font-bold text-slate-500">{totalPoints} / {nextLevelPoints} XP</span>
             </div>
           </div>
-
           <div className="w-44 h-44 flex-shrink-0 flex items-center justify-center">
             <LottiePlayer animationData={trophyAnimation} loop={true} className="w-full h-full" />
           </div>
         </Card>
 
-        {/* Global Level Card */}
         <Card className="flex flex-col justify-between p-6">
           <div className="space-y-3">
             <span className="text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider block">
@@ -153,8 +138,6 @@ export const Dashboard = () => {
             <h3 className="text-lg font-extrabold text-slate-900 dark:text-white my-0">
               Your Ranking Breakdown
             </h3>
-
-            {/* Visual Skill Indicators */}
             <div className="space-y-2.5 pt-2">
               {[
                 { label: "GitRank (GitHub)", points: userData?.points?.gitRankPoints || 0, color: "bg-blue-500" },
@@ -181,22 +164,16 @@ export const Dashboard = () => {
               })}
             </div>
           </div>
-
           <div className="mt-4 pt-3 border-t border-slate-100 dark:border-slate-800 text-[11px] text-slate-400 font-semibold flex items-center gap-1">
             <ShieldCheck className="w-4.5 h-4.5 text-emerald-500" />
             Rank points calculated from public data logs.
           </div>
         </Card>
-
       </div>
 
-      {/* Grid: Stats (Modular Cards) */}
       <StatsCards />
 
-      {/* Grid: Heatmap & Challenges */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-
-        {/* Heatmap (Takes 2 cols) */}
         <Card className="lg:col-span-2 flex flex-col justify-between">
           <div className="space-y-2">
             <div className="flex items-center justify-between">
@@ -211,8 +188,6 @@ export const Dashboard = () => {
               Consistent contributions directly increase your GitRank rating points.
             </p>
           </div>
-
-          {/* Grid Box mockup */}
           <div className="my-6 grid grid-flow-col grid-rows-7 gap-1.5 overflow-x-auto py-2 scrollbar-none">
             {heatmapCells.map((val, idx) => (
               <div
@@ -222,7 +197,6 @@ export const Dashboard = () => {
               />
             ))}
           </div>
-
           <div className="flex items-center justify-between text-xs text-slate-400 font-semibold pt-4 border-t border-slate-100 dark:border-slate-800">
             <div className="flex items-center gap-2">
               <span>Less</span>
@@ -237,7 +211,6 @@ export const Dashboard = () => {
           </div>
         </Card>
 
-        {/* Upcoming Challenges */}
         <Card className="flex flex-col justify-between">
           <div className="space-y-2">
             <h3 className="font-extrabold text-lg text-slate-900 dark:text-white my-0">
@@ -247,7 +220,6 @@ export const Dashboard = () => {
               Solve to boost your CodingVerse global rating points.
             </p>
           </div>
-
           <div className="my-4 space-y-3 flex-1">
             {challenges.map((challenge, idx) => (
               <div
@@ -265,12 +237,10 @@ export const Dashboard = () => {
                     {challenge.title}
                   </h4>
                 </div>
-
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-bold text-indigo-500 dark:text-indigo-400">
                     {challenge.points}
                   </span>
-
                   <button
                     disabled
                     className="px-3 py-1 text-[10px] font-bold rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-400 dark:text-slate-500 border border-slate-300/10 cursor-not-allowed"
@@ -282,28 +252,17 @@ export const Dashboard = () => {
               </div>
             ))}
           </div>
-
           <div className="text-[11px] text-center text-slate-400 font-semibold">
             Next challenges unlock in 8 hours.
           </div>
         </Card>
-
       </div>
 
-      {/* Grid: Streaks, Leaderboard Preview & Activity Timeline */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-
-        {/* Streak card (Owl flame) */}
         <StreakCard />
-
-        {/* Leaderboard Preview (Top 3) */}
         <RankPreview />
-
-        {/* Activity Stream Feed */}
         <ActivityFeed />
-
       </div>
-
     </div>
   );
 };

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -22,15 +22,36 @@ const heatmapColors = [
   "bg-violet-600 dark:bg-violet-600" // high
 ];
 
-const heatmapCells = Array.from({ length: 168 }, () => {
-  const rand = Math.random();
-  if (rand < 0.35) return 0;
-  if (rand < 0.65) return 1;
-  if (rand < 0.8) return 2;
-  if (rand < 0.93) return 3;
-  return 4;
-});
+const [heatmapCells, setHeatmapCells] = useState(
+  Array.from({ length: 168 }, () => 0)
+);
 
+useEffect(() => {
+  const fetchHeatmap = async () => {
+    const username = userData?.githubUsername;
+    if (!username) return;
+    try {
+      const res = await fetch(
+        `https://github-contributions-api.jogruber.de/v4/${username}?y=last`
+      );
+      const data = await res.json();
+      const contributions = data.contributions || [];
+      const last168 = contributions.slice(-168);
+      const cells = last168.map((day) => {
+        const c = day.count;
+        if (c === 0) return 0;
+        if (c <= 2) return 1;
+        if (c <= 5) return 2;
+        if (c <= 9) return 3;
+        return 4;
+      });
+      setHeatmapCells(cells);
+    } catch (err) {
+      console.error("Heatmap fetch error:", err);
+    }
+  };
+  fetchHeatmap();
+}, [userData?.githubUsername]);
 export const Dashboard = () => {
   const { userData } = useAuth();
   const [rank, setRank] = useState("Loading...");
@@ -81,7 +102,7 @@ export const Dashboard = () => {
 
   return (
     <div className="space-y-6">
-      
+
       {/* Page Header */}
       <SectionHeader
         title="Overview Dashboard"
@@ -91,26 +112,26 @@ export const Dashboard = () => {
 
       {/* Hero Welcome banner with Trophy */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        
+
         {/* Welcome & Trophy (Takes 2 cols) */}
         <Card className="lg:col-span-2 flex flex-col sm:flex-row items-center justify-between gap-6 p-8 bg-gradient-to-br from-violet-600/10 via-indigo-600/10 to-blue-600/10 border-violet-500/15">
           <div className="space-y-4 text-center sm:text-left">
             <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold bg-violet-600/20 text-violet-700 dark:text-violet-400">
               <Award className="w-4 h-4 animate-bounce" /> Level {devLevel} Developer
             </div>
-            
+
             <h2 className="text-2xl md:text-3xl font-black text-slate-900 dark:text-white leading-tight my-0">
               Welcome back, {userData?.name || "Developer"}!
             </h2>
-            
+
             <p className="text-sm md:text-base text-slate-500 dark:text-slate-400 max-w-md font-medium">
               You are currently ranked <span className="font-bold text-slate-800 dark:text-white">{rank}</span> globally. Complete daily arena challenges to boost your rank!
             </p>
 
             <div className="pt-2 flex items-center justify-center sm:justify-start gap-4">
               <div className="w-full max-w-[200px] h-2 bg-slate-200 dark:bg-slate-800 rounded-full overflow-hidden">
-                <div 
-                  className="h-full bg-gradient-to-r from-violet-600 to-indigo-600 rounded-full transition-all duration-500" 
+                <div
+                  className="h-full bg-gradient-to-r from-violet-600 to-indigo-600 rounded-full transition-all duration-500"
                   style={{ width: `${levelProgressPercent}%` }}
                 />
               </div>
@@ -132,7 +153,7 @@ export const Dashboard = () => {
             <h3 className="text-lg font-extrabold text-slate-900 dark:text-white my-0">
               Your Ranking Breakdown
             </h3>
-            
+
             {/* Visual Skill Indicators */}
             <div className="space-y-2.5 pt-2">
               {[
@@ -174,7 +195,7 @@ export const Dashboard = () => {
 
       {/* Grid: Heatmap & Challenges */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        
+
         {/* Heatmap (Takes 2 cols) */}
         <Card className="lg:col-span-2 flex flex-col justify-between">
           <div className="space-y-2">
@@ -249,7 +270,7 @@ export const Dashboard = () => {
                   <span className="text-xs font-bold text-indigo-500 dark:text-indigo-400">
                     {challenge.points}
                   </span>
-                  
+
                   <button
                     disabled
                     className="px-3 py-1 text-[10px] font-bold rounded-lg bg-slate-200 dark:bg-slate-800 text-slate-400 dark:text-slate-500 border border-slate-300/10 cursor-not-allowed"
@@ -271,7 +292,7 @@ export const Dashboard = () => {
 
       {/* Grid: Streaks, Leaderboard Preview & Activity Timeline */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        
+
         {/* Streak card (Owl flame) */}
         <StreakCard />
 


### PR DESCRIPTION
## Description
Replaced static `Math.random()` generated heatmap data with real 
GitHub contribution data fetched from GitHub Contributions API 
using the logged-in user's `githubUsername`.

**Changes:**
- Removed static `heatmapCells` array using `Math.random()`
- Added `useState` for `heatmapCells` initialized to empty
- Added `useEffect` to fetch real contribution data from 
  `github-contributions-api.jogruber.de` using `githubUsername`
- Mapped real contribution counts to heatmap color levels (0-4)

## Related Issue
Fixes #185

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
[Add screenshot of Dashboard showing real GitHub heatmap data]

## Testing Done
- [x] Visual verification on local dev server (`http://localhost:5173`)
- [x] Heatmap now shows consistent data on refresh ✅
- [x] Heatmap reflects real GitHub contributions ✅
- [x] Falls back gracefully if API fails ✅
- [x] No console errors or warnings

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the Contributing Guidelines and Code of Conduct.