### PR TITLE
Fix silent failure in referrer subscription activation (Issue #229)

### DIFF
--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -321,12 +321,17 @@ export const Onboarding = () => {
               totalEarned: currentTotalEarned + 100
             });
           } else {
-            // Safe fallback if index doc doesn't exist
-            transaction.set(referrerIndexRef, {
-              referralCode: referrerCodeClean,
-              usedBy: [activeUid],
-              totalEarned: 100
-            });
+            // Only create fallback if referrer user doc exists to prevent orphaned records
+            if (referrerDocSnap.exists()) {
+              transaction.set(referrerIndexRef, {
+                referralCode: referrerCodeClean,
+                usedBy: [activeUid],
+                totalEarned: 100
+              });
+            } else {
+              // Referrer user no longer exists, fail the transaction
+              throw new Error("Referrer user not found, unable to process referral");
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
Add referrer re-verification before fallback index creation to prevent orphaned records. When referrer subscription index doesn't exist, verify referrer user document before creating fallback index with stale referral code. Throw error if referrer user no longer exists to prevent transaction side effects.

## Changes
- Added existence check for referrer user doc in fallback path
- Fail transaction if referrer user doesn't exist instead of creating orphaned record
- Prevents race condition where referral code persists after referrer deletion

## Testing
1. Create a test account with a referral code
2. Sign out and delete the referrer account
3. Attempt to sign up with the deleted referrer's code
4. Verify that transaction fails gracefully instead of creating orphaned referral index
5. Check that error message is logged and user receives appropriate feedback

## Type of Change
- Bug fix

## Contributor Declaration
This contribution is original work and I have the right to contribute this code to the project. I understand that the project is licensed under its respective license and my contributions will be available under the same license terms.

Closes #229