### PR TITLE
feat: RankerHub Platform Activity Heatmap on Profile (#204)

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -45,5 +45,6 @@ export const systemBadges = [
   { id: "b1", name: "Pioneer", description: "First 100 users", color: "from-amber-500 to-orange-500" },
   { id: "b2", name: "Code Warrior", description: "100+ contributions", color: "from-blue-500 to-indigo-500" },
   { id: "b3", name: "Streak Master", description: "10+ day streak", color: "from-red-500 to-pink-500" },
-  { id: "b4", name: "CSS Sorceress", description: "UI layout designer", color: "from-purple-500 to-violet-500" }
+  { id: "b4", name: "CSS Sorceress", description: "UI layout designer", color: "from-purple-500 to-violet-500" },
+  { id: "b5", name: "Ranker Ambassador", description: "10+ successful referrals", color: "from-emerald-500 to-teal-500" }
 ];

--- a/src/pages/CodingVerse.jsx
+++ b/src/pages/CodingVerse.jsx
@@ -306,13 +306,46 @@ export const CodingVerse = () => {
     let newSolvedQuestions = [...answeredQuestions];
     let newCodingVersePoints = userData?.points?.codingVersePoints || 0;
     let newTotalPoints = userData?.points?.totalPoints || 0;
+    
+    // CodingVerse Streak Implementation (Issue #201)
+    let newCodingVerseStreak = userData?.codingVerseStreak || 0;
+    let newStreakPoints = userData?.points?.streakPoints || 0;
+    let newLastCodingVerseSolveDate = userData?.lastCodingVerseSolveDate || null;
+    let earnedStreakPoints = 0;
 
     if (isCorrect) {
       newSolvedQuestions = [...answeredQuestions, qId];
       newCodingVersePoints += earnedPoints;
+
+      // Ensure timezone-agnostic boundaries using strict UTC Date strings
+      const today = new Date();
+      const todayUTCStr = today.toISOString().split('T')[0];
+      const todayUTC = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+
+      if (newLastCodingVerseSolveDate) {
+        if (todayUTCStr !== newLastCodingVerseSolveDate) {
+          const lastDateParts = newLastCodingVerseSolveDate.split('-');
+          const lastUTC = Date.UTC(parseInt(lastDateParts[0]), parseInt(lastDateParts[1]) - 1, parseInt(lastDateParts[2]));
+          const diffDays = Math.floor((todayUTC - lastUTC) / (1000 * 60 * 60 * 24));
+
+          if (diffDays === 1) {
+            newCodingVerseStreak += 1; // Maintained consecutive sequence
+          } else if (diffDays > 1) {
+            newCodingVerseStreak = 1; // Broken streak, reset
+          }
+          earnedStreakPoints = 5; // +5 XP for each new active solving day
+          newLastCodingVerseSolveDate = todayUTCStr;
+        }
+      } else {
+        newCodingVerseStreak = 1;
+        earnedStreakPoints = 5;
+        newLastCodingVerseSolveDate = todayUTCStr;
+      }
+
+      newStreakPoints += earnedStreakPoints;
       newTotalPoints = (userData?.points?.gitRankPoints || 0) + 
                        (userData?.points?.referralPoints || 0) + 
-                       (userData?.points?.streakPoints || 0) + 
+                       newStreakPoints + 
                        newCodingVersePoints;
     }
 
@@ -321,14 +354,23 @@ export const CodingVerse = () => {
     if (user && userData) {
       const userRef = doc(db, "users", user.uid);
       try {
-        await updateDoc(userRef, {
+        const updatePayload = {
           "points.codingVersePoints": newCodingVersePoints,
           "points.totalPoints": newTotalPoints,
           "solvedCodingVerseQuestions": newSolvedQuestions,
           "attemptedCodingVerseQuestions": newAttemptedQuestions,
           "codingVerseAnswers": newAnswersState
-        });
-        console.log(`Submitted answer for ${qId}. Correct: ${isCorrect}. Points earned: ${isCorrect ? earnedPoints : 0}.`);
+        };
+
+        // Only update streak data if they successfully answered and progressed
+        if (isCorrect) {
+          updatePayload["points.streakPoints"] = newStreakPoints;
+          updatePayload["codingVerseStreak"] = newCodingVerseStreak;
+          updatePayload["lastCodingVerseSolveDate"] = newLastCodingVerseSolveDate;
+        }
+
+        await updateDoc(userRef, updatePayload);
+        console.log(`Submitted answer for ${qId}. Correct: ${isCorrect}. Arena Points: ${isCorrect ? earnedPoints : 0}. Streak Points: ${earnedStreakPoints}`);
       } catch (err) {
         console.error("Failed to update points in database:", err);
       }
@@ -342,7 +384,7 @@ export const CodingVerse = () => {
     }
   };
 
-  // Calculate total XP gained from solved questions dynamically (for sidebar & mobile views)
+  // Calculate total XP gained from solved questions dynamically
   const codingVerseXPGained = answeredQuestions.reduce((sum, qId) => {
     const q = theoryQuestions.find(item => item.id === qId);
     if (!q) return sum;
@@ -390,7 +432,6 @@ export const CodingVerse = () => {
                 {/* 1. Mascot Post Header */}
                 <div className="flex items-center justify-between p-4 border-b border-slate-100 dark:border-slate-800 bg-white/40 dark:bg-slate-900/40">
                   <div className="flex items-center gap-3">
-                    {/* Mascot profile photo with Instagram-style colored story ring */}
                     <div className="w-10 h-10 rounded-full p-[2px] bg-gradient-to-tr from-yellow-500 via-red-500 to-purple-600 flex items-center justify-center shadow-md">
                       <div className="w-full h-full rounded-full bg-slate-900 flex items-center justify-center text-lg select-none">
                         🦉
@@ -435,12 +476,10 @@ export const CodingVerse = () => {
                   onDoubleClick={() => handleDoubleTap(q.id)}
                   className="relative bg-slate-950 p-6 min-h-[160px] flex flex-col justify-center border-b border-slate-100 dark:border-slate-800 select-none group cursor-pointer"
                 >
-                  {/* Floating instructions overlay on hover */}
                   <div className="absolute top-2 right-3 opacity-0 group-hover:opacity-100 transition-opacity duration-300 text-[9px] font-bold text-slate-500 tracking-wide flex items-center gap-1">
                     <span className="px-1.5 py-0.5 bg-slate-900 rounded border border-slate-800">Double-tap to like</span>
                   </div>
 
-                  {/* Popout Heart Animation */}
                   <AnimatePresence>
                     {showHeartAnimation[q.id] && (
                       <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-20">
@@ -457,18 +496,16 @@ export const CodingVerse = () => {
                     )}
                   </AnimatePresence>
 
-                  {/* Question snippet title */}
                   <div className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-3 flex items-center gap-1">
                     <Terminal className="w-3.5 h-3.5 text-emerald-500" /> SOURCE_CODE.{q.language === "Python" ? "py" : "java"}
                   </div>
 
-                  {/* Code block */}
                   <div className="font-mono text-xs text-emerald-400 overflow-x-auto leading-relaxed select-text whitespace-pre bg-black/30 p-4 rounded-xl border border-slate-900">
                     {q.code}
                   </div>
                 </div>
 
-                {/* 3. Action bar (Like only - removed comment, share, bookmark) */}
+                {/* 3. Action bar */}
                 <div className="p-4 space-y-4">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-4">
@@ -481,7 +518,6 @@ export const CodingVerse = () => {
                     </div>
                   </div>
 
-                  {/* Like statistics */}
                   <div className="text-xs font-bold text-slate-700 dark:text-slate-350 select-none">
                     Liked by <span className="hover:underline cursor-pointer font-black text-slate-900 dark:text-white">git_wizard</span> and{" "}
                     <span className="hover:underline cursor-pointer font-black text-slate-900 dark:text-white">
@@ -489,7 +525,6 @@ export const CodingVerse = () => {
                     </span>
                   </div>
 
-                  {/* Post caption (Question) */}
                   <div className="text-xs leading-relaxed">
                     <span className="font-extrabold text-slate-900 dark:text-white mr-1.5 hover:underline cursor-pointer">
                       oliver_mascot
@@ -650,11 +685,6 @@ export const CodingVerse = () => {
                             </span>
                             {q.explanation}
                           </p>
-                          <div className="flex items-center gap-3 text-[10px] font-bold text-slate-400">
-                            <span>Just now</span>
-                            <button className="hover:text-slate-200 transition">Like</button>
-                            <button className="hover:text-slate-200 transition">Reply</button>
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -677,7 +707,6 @@ export const CodingVerse = () => {
               </span>
               
               <div className="flex items-center gap-3">
-                {/* Real User Profile picture instead of random gender emojis */}
                 <img 
                   src={userData?.avatar || user?.photoURL || "https://avatars.githubusercontent.com/u/9919?v=4"} 
                   alt="Profile Avatar"
@@ -709,6 +738,13 @@ export const CodingVerse = () => {
                   <span className="text-slate-400">CodingVerse XP Gained</span>
                   <span className="text-emerald-500 font-extrabold">+{codingVerseXPGained} XP</span>
                 </div>
+                
+                {/* NEW LOGIC UI: Live CodingVerse Streak Display */}
+                <div className="flex justify-between items-center text-xs font-bold pt-1 border-b border-slate-100 dark:border-slate-800/50 pb-2">
+                  <span className="text-slate-400">Arena Streak</span>
+                  <span className="text-orange-500 font-extrabold">🔥 {userData?.codingVerseStreak || 0} Days</span>
+                </div>
+
                 {/* Displaying CodingVerse global leaderboard rank */}
                 <div className="flex justify-between items-center text-xs font-bold pt-1">
                   <span className="text-slate-400">CodingVerse Rank</span>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -23,21 +23,32 @@ const heatmapColors = [
 export const Dashboard = () => {
   const { userData } = useAuth();
   const [rank, setRank] = useState("Loading...");
+  
+  // Initialize with 168 empty cells (24 weeks * 7 days)
   const [heatmapCells, setHeatmapCells] = useState(
     Array.from({ length: 168 }, () => 0)
   );
 
+  // 1. Fetch REAL GitHub Contributions for Heatmap
   useEffect(() => {
     const fetchHeatmap = async () => {
       const username = userData?.githubUsername;
       if (!username) return;
+      
       try {
         const res = await fetch(
           `https://github-contributions-api.jogruber.de/v4/${username}?y=last`
         );
+        
+        if (!res.ok) throw new Error("API Limit or Network Error");
+        
         const data = await res.json();
         const contributions = data.contributions || [];
+        
+        // Take the last 168 days of real data
         const last168 = contributions.slice(-168);
+        
+        // Map raw commit counts to intensity levels (0-4)
         const cells = last168.map((day) => {
           const c = day.count;
           if (c === 0) return 0;
@@ -46,14 +57,26 @@ export const Dashboard = () => {
           if (c <= 9) return 3;
           return 4;
         });
-        setHeatmapCells(cells);
+        
+        // Ensure we always have exactly 168 cells for UI consistency
+        if (cells.length < 168) {
+          const padding = Array.from({ length: 168 - cells.length }, () => 0);
+          setHeatmapCells([...padding, ...cells]);
+        } else {
+          setHeatmapCells(cells);
+        }
+        
       } catch (err) {
-        console.error("Heatmap fetch error:", err);
+        console.error("Heatmap fetch error (Falling back to empty grid):", err);
+        // Fallback to empty grid if API fails (prevents fake data from rendering)
+        setHeatmapCells(Array.from({ length: 168 }, () => 0));
       }
     };
+    
     fetchHeatmap();
   }, [userData?.githubUsername]);
 
+  // 2. Fetch Dynamic Leaderboard Rank
   useEffect(() => {
     if (!userData || !userData.points) return;
     const fetchRank = async () => {
@@ -193,7 +216,7 @@ export const Dashboard = () => {
               <div
                 key={idx}
                 className={`w-3.5 h-3.5 rounded-sm border border-slate-200/5 dark:border-slate-800/5 hover:ring-2 hover:ring-violet-500/40 transition-all duration-150 ${heatmapColors[val]}`}
-                title={`Level: ${val}`}
+                title={`Activity Level: ${val}`}
               />
             ))}
           </div>

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { Search, Filter, Star, Trophy, RefreshCw, GitCommit, Calendar, BookOpen, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Search, Filter, Star, Trophy, RefreshCw, GitCommit, Calendar, BookOpen, AlertCircle, CheckCircle2, Users, Medal } from "lucide-react";
 import { collection, query, doc, where, orderBy, limit, startAfter, onSnapshot, getDocs, runTransaction } from "firebase/firestore";
 import { useSearchParams } from "react-router-dom";
-import { TableVirtuoso } from "react-virtuoso"; // <-- VIRTUALIZATION IMPORT ADDED
+import { TableVirtuoso } from "react-virtuoso"; 
 import { db } from "../lib/firebase";
 import { useAuth } from "../context/AuthContext";
 import Card from "../components/ui/Card";
@@ -12,19 +12,23 @@ import axios from "axios";
 
 export const GitRank = () => {
   const { user, userData, fetchGitHubStats, login } = useAuth();
-// ============================================================
+
+  // ============================================================
   // ISSUE #194: URL Parameter Sync for State Persistence
   // ============================================================
   const [searchParams, setSearchParams] = useSearchParams();
   const searchTerm = searchParams.get("search") || "";
   const selectedLanguage = searchParams.get("lang") || "All";
 
+  // Active Tab for Referral Leaderboard (Issue #214)
+  const [activeTab, setActiveTab] = useState("gitrank"); // "gitrank" | "referrals"
+
   const handleSearchChange = (e) => {
     const val = e.target.value;
     const newParams = new URLSearchParams(searchParams);
     if (val) newParams.set("search", val);
     else newParams.delete("search");
-// Use replace: true so we don't bloat the browser history with every keystroke
+    // Use replace: true so we don't bloat the browser history with every keystroke
     setSearchParams(newParams, { replace: true });
   };
 
@@ -58,18 +62,24 @@ export const GitRank = () => {
 
   const languages = ["All", "TypeScript", "Rust", "Go", "Python", "Kotlin", "Ruby", "JavaScript"];
 
-  // 1. Real-time Leaderboard Listener (Server-Side Filtered - NOW OPEN FOR GUESTS)
+  // 1. Real-time Leaderboard Listener (Server-Side Filtered)
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoadingUsers(true);
 
-// Build the query dynamically based on language selection and strict sorting
+    // Build the query dynamically based on Active Tab
     const constraints = [
       where("onboardingStatus", "==", "complete"),
-      orderBy("points.gitRankPoints", "desc"),
-      orderBy("githubStats.commits", "desc"),
-      orderBy("githubUsername", "asc")
     ];
+
+    if (activeTab === "gitrank") {
+      constraints.push(orderBy("points.gitRankPoints", "desc"));
+      constraints.push(orderBy("githubStats.commits", "desc"));
+    } else {
+      constraints.push(orderBy("points.referralPoints", "desc"));
+    }
+    
+    constraints.push(orderBy("githubUsername", "asc"));
 
     // DB level language filter
     if (selectedLanguage !== "All") {
@@ -88,15 +98,12 @@ export const GitRank = () => {
           users.push(doc.data());
         });
 
-        // Assign ranks (pre-sorted at database level)
         const ranked = users.map((u, i) => ({
           ...u,
           rank: i + 1
         }));
 
         setUsersList(ranked);
-        
-        // Setup pagination cursors
         setLastVisible(snapshot.docs[snapshot.docs.length - 1]);
         setHasMore(snapshot.docs.length === 50); 
         setLoadingUsers(false);
@@ -108,7 +115,8 @@ export const GitRank = () => {
     );
 
     return () => unsubscribe();
-}, [selectedLanguage]); // Removed 'user' dependency to allow guest fetching
+  }, [selectedLanguage, activeTab]); 
+
   // Pagination Function (Fetch next 50)
   const loadMoreUsers = async () => {
     if (!lastVisible || !hasMore || loadingMore) return;
@@ -117,12 +125,17 @@ export const GitRank = () => {
     try {
       const constraints = [
         where("onboardingStatus", "==", "complete"),
-        orderBy("points.gitRankPoints", "desc"),
-        orderBy("githubStats.commits", "desc"),
-        orderBy("githubUsername", "asc")
       ];
 
-      // Maintain server-side language filter during pagination
+      if (activeTab === "gitrank") {
+        constraints.push(orderBy("points.gitRankPoints", "desc"));
+        constraints.push(orderBy("githubStats.commits", "desc"));
+      } else {
+        constraints.push(orderBy("points.referralPoints", "desc"));
+      }
+      
+      constraints.push(orderBy("githubUsername", "asc"));
+
       if (selectedLanguage !== "All") {
         constraints.push(where("githubStats.primaryLanguage", "==", selectedLanguage));
       }
@@ -131,7 +144,6 @@ export const GitRank = () => {
       constraints.push(limit(50));
 
       const nextQuery = query(collection(db, "users"), ...constraints);
-
       const snapshot = await getDocs(nextQuery);
 
       if (snapshot.empty) {
@@ -145,7 +157,6 @@ export const GitRank = () => {
         newUsers.push(doc.data());
       });
 
-      // Calculate ranks correctly for paginated data
       const currentLength = usersList.length;
       const rankedNewUsers = newUsers.map((u, i) => ({
         ...u,
@@ -162,7 +173,7 @@ export const GitRank = () => {
     }
   };
 
-// 2. Fetch GitHub Events/Repos for Charts (Authenticated Only)
+  // 2. Fetch GitHub Events/Repos for Charts (Authenticated Only)
   useEffect(() => {
     if (!userData?.githubUsername) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -299,7 +310,7 @@ export const GitRank = () => {
     return `${mins}m ${secs}s`;
   };
 
-  // Filter leaderboard lists (Only Search is client side now, filtering cached DB data)
+  // Filter leaderboard lists (Only Search is client side now)
   const filteredData = useMemo(() => {
     return usersList.filter((u) => {
       const name = u.name || "";
@@ -314,7 +325,7 @@ export const GitRank = () => {
     return usersList.slice(0, 3);
   }, [usersList]);
 
-  // Chart Parsing 1: Weekly Activity (NO FAKE DATA)
+  // Chart Parsing
   const weeklyActivityData = useMemo(() => {
     const weeks = Array.from({ length: 8 }, (_, idx) => {
       const start = new Date();
@@ -325,7 +336,6 @@ export const GitRank = () => {
       return { start, end, commits: 0, prs: 0, reviews: 0, label };
     }).reverse();
 
-    // If events are empty, it gracefully processes 0 loops and returns accurate flat 0-line graph
     events.forEach((event) => {
       const eventDate = new Date(event.created_at);
       const weekIdx = weeks.findIndex((w) => eventDate >= w.start && eventDate < w.end);
@@ -343,9 +353,8 @@ export const GitRank = () => {
     return weeks;
   }, [events]);
 
-  // Chart Parsing 2: Languages Frequency (NO FAKE DATA)
   const languageChartData = useMemo(() => {
-    if (!repos.length) return []; // Explicitly return empty array when no data
+    if (!repos.length) return []; 
     
     const counts = {};
     repos.forEach((r) => {
@@ -378,9 +387,8 @@ export const GitRank = () => {
       .slice(0, 5);
   }, [repos]);
 
-  // Chart Parsing 3: Repository Contributions (NO FAKE DATA)
   const repositoryContributionData = useMemo(() => {
-    if (!events.length) return []; // Explicitly return empty array when no data
+    if (!events.length) return [];
 
     const counts = {};
     events.forEach((e) => {
@@ -400,7 +408,6 @@ export const GitRank = () => {
       .slice(0, 5);
   }, [events]);
 
-  // SVG Line Chart coordinates calculation
   const maxVal = Math.max(
     ...weeklyActivityData.map((d) => d.commits),
     ...weeklyActivityData.map((d) => d.prs),
@@ -573,7 +580,6 @@ export const GitRank = () => {
 
           {/* User GitHub Graphs & Charts */}
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6">
-            {/* SVG Weekly activity trend */}
             <Card className="!p-3 sm:!p-5 flex flex-col justify-between">
               <div>
                 <h4 className="font-extrabold text-slate-900 dark:text-white mt-0 mb-1 flex items-center gap-1.5">
@@ -591,7 +597,6 @@ export const GitRank = () => {
               ) : (
                 <div className="w-full flex items-center justify-center">
                   <svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} className="w-full h-auto overflow-visible">
-                    {/* Gridlines */}
                     {[0, 0.25, 0.5, 0.75, 1].map((r, i) => {
                       const y = chartHeight - paddingY - r * (chartHeight - 2 * paddingY);
                       return (
@@ -607,7 +612,6 @@ export const GitRank = () => {
                       );
                     })}
 
-                    {/* Commits Area/Line */}
                     {areaCommits && (
                       <path d={areaCommits} className="fill-blue-500/5 dark:fill-blue-500/5" />
                     )}
@@ -622,7 +626,6 @@ export const GitRank = () => {
                       />
                     )}
 
-                    {/* PR Area/Line */}
                     {areaPrs && (
                       <path d={areaPrs} className="fill-violet-500/5 dark:fill-violet-500/5" />
                     )}
@@ -637,7 +640,6 @@ export const GitRank = () => {
                       />
                     )}
 
-                    {/* Reviews Area/Line */}
                     {areaReviews && (
                       <path d={areaReviews} className="fill-pink-500/5 dark:fill-pink-500/5" />
                     )}
@@ -652,7 +654,6 @@ export const GitRank = () => {
                       />
                     )}
 
-                    {/* Interaction Dots */}
                     {pointsCommits.map((p, i) => (
                       <circle
                         key={`c-${i}`}
@@ -674,7 +675,6 @@ export const GitRank = () => {
                       />
                     ))}
 
-                    {/* X-axis Labels */}
                     {weeklyActivityData.map((d, i) => {
                       const x = paddingX + (i / (weeklyActivityData.length - 1)) * (chartWidth - 2 * paddingX);
                       return (
@@ -693,7 +693,6 @@ export const GitRank = () => {
                 </div>
               )}
 
-              {/* Chart Legend */}
               <div className="flex items-center justify-center gap-4 text-[10px] font-bold text-slate-400 mt-2">
                 <span className="flex items-center gap-1">
                   <span className="w-2 h-2 rounded-full bg-blue-500" /> Commits
@@ -707,7 +706,6 @@ export const GitRank = () => {
               </div>
             </Card>
 
-            {/* Language Breakdown */}
             <Card className="!p-3 sm:!p-5 flex flex-col justify-between">
               <div>
                 <h4 className="font-extrabold text-slate-900 dark:text-white mt-0 mb-1 flex items-center gap-1.5">
@@ -755,7 +753,6 @@ export const GitRank = () => {
               )}
             </Card>
 
-            {/* Repository breakdown */}
             <Card className="!p-3 sm:!p-5 flex flex-col justify-between">
               <div>
                 <h4 className="font-extrabold text-slate-900 dark:text-white mt-0 mb-1 flex items-center gap-1.5">
@@ -797,7 +794,6 @@ export const GitRank = () => {
           </div>
         </div>
       ) : (
-        /* Guest User CTA */
         <Card className="p-6 sm:p-8 text-center max-w-xl mx-auto space-y-6 bg-gradient-to-br from-violet-600/10 via-transparent to-blue-500/10 border-violet-500/20 backdrop-blur-md">
           <div className="w-16 h-16 rounded-2xl bg-gradient-to-tr from-violet-600 to-indigo-600 text-white flex items-center justify-center mx-auto shadow-lg shadow-violet-500/25">
             <Trophy className="w-8 h-8" />
@@ -819,7 +815,7 @@ export const GitRank = () => {
         </Card>
       )}
 
-      {/* 2. Top 3 Contributors Grid (Now visible to everyone) */}
+      {/* 2. Top 3 Contributors Grid (Dynamically adjust based on active tab) */}
       {!loadingUsers && topContributors.length > 0 && (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {topContributors.map((u, idx) => (
@@ -864,29 +860,75 @@ export const GitRank = () => {
               </div>
 
               <div className="mt-4 pt-4 border-t border-slate-100 dark:border-slate-800/80 w-full flex items-center justify-around text-xs">
-                <div>
-                  <span className="block font-black text-slate-900 dark:text-white leading-none">
-                    {u.githubStats?.commits || 0}
-                  </span>
-                  <span className="text-[9px] text-slate-400 font-bold uppercase mt-1 block">Commits</span>
-                </div>
-                <div className="h-6 w-[1px] bg-slate-200 dark:bg-slate-800" />
-                <div>
-                  <span className="block font-black text-violet-600 dark:text-violet-400 leading-none">
-                    {u.points?.gitRankPoints?.toLocaleString() || 0}
-                  </span>
-                  <span className="text-[9px] text-slate-400 font-bold uppercase mt-1 block">Git Points</span>
-                </div>
+                {activeTab === "gitrank" ? (
+                  <>
+                    <div>
+                      <span className="block font-black text-slate-900 dark:text-white leading-none">
+                        {u.githubStats?.commits || 0}
+                      </span>
+                      <span className="text-[9px] text-slate-400 font-bold uppercase mt-1 block">Commits</span>
+                    </div>
+                    <div className="h-6 w-[1px] bg-slate-200 dark:bg-slate-800" />
+                    <div>
+                      <span className="block font-black text-violet-600 dark:text-violet-400 leading-none">
+                        {u.points?.gitRankPoints?.toLocaleString() || 0}
+                      </span>
+                      <span className="text-[9px] text-slate-400 font-bold uppercase mt-1 block">Git Points</span>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <span className="block font-black text-slate-900 dark:text-white leading-none">
+                        {Math.floor((u.points?.referralPoints || 0) / 100)}
+                      </span>
+                      <span className="text-[9px] text-slate-400 font-bold uppercase mt-1 block">Valid Invites</span>
+                    </div>
+                    <div className="h-6 w-[1px] bg-slate-200 dark:bg-slate-800" />
+                    <div>
+                      <span className="block font-black text-emerald-600 dark:text-emerald-400 leading-none">
+                        {u.points?.referralPoints?.toLocaleString() || 0}
+                      </span>
+                      <span className="text-[9px] text-slate-400 font-bold uppercase mt-1 block">Referral Pts</span>
+                    </div>
+                  </>
+                )}
               </div>
             </Card>
           ))}
         </div>
       )}
 
-      {/* 3. Leaderboard Table / Search & Filters Controls (Unlocked) */}
+      {/* 3. Leaderboard Table / Search & Filters Controls */}
       <Card className="!p-3 sm:!p-6">
+        
+        {/* NEW TAB SYSTEM FOR REFERRAL LEADERBOARD */}
+        <div className="flex items-center gap-2 mb-6 p-1 bg-slate-100 dark:bg-slate-800/50 rounded-xl w-fit">
+          <button
+            onClick={() => setActiveTab("gitrank")}
+            className={`px-4 py-2 text-xs font-bold rounded-lg transition-all flex items-center gap-2 ${
+              activeTab === "gitrank"
+                ? "bg-white dark:bg-slate-700 text-violet-600 dark:text-violet-400 shadow-sm"
+                : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+            }`}
+          >
+            <GitCommit className="w-3.5 h-3.5" />
+            GitRank Leaderboard
+          </button>
+          <button
+            onClick={() => setActiveTab("referrals")}
+            className={`px-4 py-2 text-xs font-bold rounded-lg transition-all flex items-center gap-2 ${
+              activeTab === "referrals"
+                ? "bg-white dark:bg-slate-700 text-emerald-600 dark:text-emerald-400 shadow-sm"
+                : "text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+            }`}
+          >
+            <Users className="w-3.5 h-3.5" />
+            Top Recruiters
+          </button>
+        </div>
+
         <div className="flex flex-col lg:flex-row items-center justify-between gap-4 pb-6 border-b border-slate-100 dark:border-slate-800">
-          {/* Search */}
           <div className="relative w-full sm:max-w-xs">
             <Search className="w-4 h-4 text-slate-400 absolute left-3 top-1/2 -translate-y-1/2" />
             <input
@@ -898,7 +940,6 @@ export const GitRank = () => {
             />
           </div>
 
-          {/* Languages Filter List */}
           <div className="flex items-center gap-2 overflow-x-auto w-full lg:w-auto pb-2 lg:pb-0 scrollbar-none">
             <Filter className="w-4 h-4 text-slate-400 flex-shrink-0" />
             <div className="flex gap-1.5">
@@ -922,9 +963,6 @@ export const GitRank = () => {
           </div>
         </div>
 
-        {/* ========================================== */}
-        {/* VIRTUALIZED TABLE IMPLEMENTATION           */}
-        {/* ========================================== */}
         <div className="overflow-x-auto overflow-y-hidden w-full">
           {loadingUsers ? (
             <div className="py-20 text-center text-slate-400">
@@ -946,10 +984,22 @@ export const GitRank = () => {
                   <th className="py-3 px-2 sm:px-4">Rank</th>
                   <th className="py-3 px-2 sm:px-4">Developer</th>
                   <th className="py-3 px-2 sm:px-4">Language</th>
-                  <th className="py-3 px-2 sm:px-4 text-center">Commits</th>
-                  <th className="py-3 px-2 sm:px-4 text-center">PRs</th>
-                  <th className="py-3 px-2 sm:px-4 text-center">Reviews</th>
-                  <th className="py-3 px-2 sm:px-4 text-right">Points</th>
+                  
+                  {/* DYNAMIC COLUMNS BASED ON ACTIVE TAB */}
+                  {activeTab === "gitrank" ? (
+                    <>
+                      <th className="py-3 px-2 sm:px-4 text-center">Commits</th>
+                      <th className="py-3 px-2 sm:px-4 text-center">PRs</th>
+                      <th className="py-3 px-2 sm:px-4 text-center">Reviews</th>
+                      <th className="py-3 px-2 sm:px-4 text-right">Git Points</th>
+                    </>
+                  ) : (
+                    <>
+                      <th className="py-3 px-2 sm:px-4 text-center">Invites Sent</th>
+                      <th className="py-3 px-2 sm:px-4 text-center">Recruiter Status</th>
+                      <th className="py-3 px-2 sm:px-4 text-right">Referral Points</th>
+                    </>
+                  )}
                 </tr>
               )}
               itemContent={(index, u) => (
@@ -969,10 +1019,30 @@ export const GitRank = () => {
                   <td className="py-3 sm:py-4 px-2 sm:px-4">
                     <span className="px-1.5 sm:px-2 py-0.5 rounded-md text-[9px] sm:text-[10px] font-bold bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border border-slate-200/10 dark:border-slate-800/10">{u.githubStats?.primaryLanguage || "JS"}</span>
                   </td>
-                  <td className="py-3 sm:py-4 px-2 sm:px-4 text-center font-bold text-slate-800 dark:text-slate-200 text-xs sm:text-sm">{u.githubStats?.commits || 0}</td>
-                  <td className="py-3 sm:py-4 px-2 sm:px-4 text-center font-bold text-violet-600 dark:text-violet-400 text-xs sm:text-sm">{u.githubStats?.prs || 0}</td>
-                  <td className="py-3 sm:py-4 px-2 sm:px-4 text-center font-bold text-pink-600 dark:text-pink-400 text-xs sm:text-sm">{u.githubStats?.reviews || 0}</td>
-                  <td className="py-3 sm:py-4 px-2 sm:px-4 text-right font-black text-slate-900 dark:text-white text-xs sm:text-sm">{u.points?.gitRankPoints?.toLocaleString() || 0}</td>
+                  
+                  {/* DYNAMIC ROW CONTENT BASED ON ACTIVE TAB */}
+                  {activeTab === "gitrank" ? (
+                    <>
+                      <td className="py-3 sm:py-4 px-2 sm:px-4 text-center font-bold text-slate-800 dark:text-slate-200 text-xs sm:text-sm">{u.githubStats?.commits || 0}</td>
+                      <td className="py-3 sm:py-4 px-2 sm:px-4 text-center font-bold text-violet-600 dark:text-violet-400 text-xs sm:text-sm">{u.githubStats?.prs || 0}</td>
+                      <td className="py-3 sm:py-4 px-2 sm:px-4 text-center font-bold text-pink-600 dark:text-pink-400 text-xs sm:text-sm">{u.githubStats?.reviews || 0}</td>
+                      <td className="py-3 sm:py-4 px-2 sm:px-4 text-right font-black text-slate-900 dark:text-white text-xs sm:text-sm">{u.points?.gitRankPoints?.toLocaleString() || 0}</td>
+                    </>
+                  ) : (
+                    <>
+                      <td className="py-3 sm:py-4 px-2 sm:px-4 text-center font-bold text-slate-800 dark:text-slate-200 text-xs sm:text-sm">{Math.floor((u.points?.referralPoints || 0) / 100)}</td>
+                      <td className="py-3 sm:py-4 px-2 sm:px-4 text-center">
+                        {(u.points?.referralPoints || 0) >= 1000 ? (
+                          <span className="inline-flex items-center gap-1 text-[10px] sm:text-xs font-black text-amber-500 bg-amber-500/10 border border-amber-500/20 px-2 py-0.5 rounded-lg">
+                            <Medal className="w-3 h-3" /> Ambassador
+                          </span>
+                        ) : (
+                          <span className="text-[10px] sm:text-xs font-bold text-slate-400">Recruiter</span>
+                        )}
+                      </td>
+                      <td className="py-3 sm:py-4 px-2 sm:px-4 text-right font-black text-emerald-500 dark:text-emerald-400 text-xs sm:text-sm">{u.points?.referralPoints?.toLocaleString() || 0}</td>
+                    </>
+                  )}
                 </>
               )}
             />

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -17,7 +17,8 @@ import {
   HelpCircle,
   Search,
   Image,
-  AlertCircle
+  AlertCircle,
+  Zap
 } from "lucide-react";
 import { Github, Linkedin, Instagram } from "../components/ui/Icons";
 import { query, collection, where, getCountFromServer, doc, getDoc, writeBatch, updateDoc } from "firebase/firestore";
@@ -55,8 +56,8 @@ export const Profile = () => {
 
   const editDropdownRef = useRef(null);
 
-  // 1. Profile Real Heatmap State (Issue #205 Fix)
-  const [heatmap, setHeatmap] = useState({
+  // GitHub Real Heatmap State
+  const [githubHeatmap, setGithubHeatmap] = useState({
     grid: Array.from({ length: 16 }, () => Array(7).fill({ intensity: 0, daysAgo: 0, count: 0 })),
     total: 0
   });
@@ -65,7 +66,6 @@ export const Profile = () => {
     if (collegeSearch.trim() === "" || collegeSearch === "Other") {
       return collegesList;
     }
-
     const searchLower = collegeSearch.toLowerCase();
     return collegesList.filter((col) => col.toLowerCase().includes(searchLower));
   }, [collegeSearch]);
@@ -242,9 +242,9 @@ export const Profile = () => {
     fetchRank();
   }, [userData]);
 
-  // Fetch REAL Profile Heatmap Data replacing the old useMemo fake math (Issue #205)
+  // Fetch REAL Profile Heatmap Data for GitHub
   useEffect(() => {
-    const fetchProfileHeatmap = async () => {
+    const fetchGithubHeatmap = async () => {
       const username = userData?.githubUsername;
       if (!username) return;
 
@@ -255,7 +255,6 @@ export const Profile = () => {
         const data = await res.json();
         const contributions = data.contributions || [];
 
-        // We need exactly 112 days to form 16 weeks * 7 days
         const last112 = contributions.slice(-112);
         let totalActivity = 0;
         const grid = [];
@@ -281,7 +280,6 @@ export const Profile = () => {
           }
         });
 
-        // Pad if account has fewer than 112 days of history
         if (grid.length < 16) {
           const diff = 16 - grid.length;
           const padWeek = Array(7).fill({ intensity: 0, daysAgo: 0, count: 0 });
@@ -289,19 +287,62 @@ export const Profile = () => {
           grid.unshift(...padGrid);
         }
 
-        setHeatmap({ grid, total: totalActivity });
+        setGithubHeatmap({ grid, total: totalActivity });
       } catch (err) {
         console.error("Profile heatmap fetch error:", err);
-        // Fallback to strict zeros
-        setHeatmap({
+        setGithubHeatmap({
           grid: Array.from({ length: 16 }, () => Array(7).fill({ intensity: 0, daysAgo: 0, count: 0 })),
           total: 0
         });
       }
     };
 
-    fetchProfileHeatmap();
+    fetchGithubHeatmap();
   }, [userData?.githubUsername]);
+
+  // Issue #204: RankerHub Platform Activity Heatmap Logic
+  const platformHeatmap = useMemo(() => {
+    const logs = userData?.platformActivityLogs || [];
+    const weeks = 16;
+    const daysPerWeek = 7;
+    const data = [];
+    let activityTotal = 0;
+
+    const today = new Date();
+    today.setHours(0,0,0,0);
+
+    // Map timestamps to frequency counts
+    const activityMap = {};
+    logs.forEach(log => {
+       const d = new Date(log);
+       d.setHours(0,0,0,0);
+       const key = d.getTime();
+       activityMap[key] = (activityMap[key] || 0) + 1;
+    });
+
+    for (let w = 0; w < weeks; w++) {
+      const weekData = [];
+      for (let d = 0; d < daysPerWeek; d++) {
+        const daysAgo = ((weeks - 1 - w) * daysPerWeek) + (daysPerWeek - 1 - d);
+        const targetDate = new Date(today);
+        targetDate.setDate(today.getDate() - daysAgo);
+        const key = targetDate.getTime();
+        
+        const count = activityMap[key] || 0;
+        activityTotal += count;
+        
+        let intensity = 0;
+        if (count > 0 && count <= 2) intensity = 1;
+        else if (count > 2 && count <= 5) intensity = 2;
+        else if (count > 5 && count <= 9) intensity = 3;
+        else if (count > 9) intensity = 4;
+
+        weekData.push({ intensity, daysAgo, count });
+      }
+      data.push(weekData);
+    }
+    return { grid: data, total: activityTotal };
+  }, [userData?.platformActivityLogs]);
 
   const handleShareProfile = () => {
     const code = userData?.referralCode || "NEWCODE";
@@ -312,14 +353,11 @@ export const Profile = () => {
 
   const getDiscordProfileUrl = (discordValue) => {
     if (!discordValue) return null;
-
     const value = discordValue.trim();
     if (!value) return null;
-
     if (/^https?:\/\//i.test(value)) {
       return value;
     }
-
     const userId = value.replace(/^@/, "");
     return `https://discord.com/users/${encodeURIComponent(userId)}`;
   };
@@ -422,7 +460,19 @@ export const Profile = () => {
   ];
   const earnedPointsTotal = pointsEngines.reduce((sum, engine) => sum + Math.max(engine.value, 0), 0);
 
-  const getIntensityColor = (intensity) => {
+  // GitHub Heatmap Colors (Green/Emerald mapping)
+  const getGithubIntensityColor = (intensity) => {
+    switch(intensity) {
+      case 4: return "bg-emerald-600 dark:bg-emerald-500";
+      case 3: return "bg-emerald-500/80 dark:bg-emerald-500/80";
+      case 2: return "bg-emerald-400/60 dark:bg-emerald-400/60";
+      case 1: return "bg-emerald-300/40 dark:bg-emerald-300/40";
+      default: return "bg-slate-100 dark:bg-slate-800/50";
+    }
+  };
+
+  // RankerHub Heatmap Colors (Violet/Indigo mapping)
+  const getPlatformIntensityColor = (intensity) => {
     switch(intensity) {
       case 4: return "bg-violet-600 dark:bg-violet-500";
       case 3: return "bg-violet-500/80 dark:bg-violet-500/80";
@@ -683,7 +733,6 @@ export const Profile = () => {
               </div>
             ))}
           </div>
-          {/* Toast Stack */}
           <div className="fixed bottom-6 right-5 z-50 flex flex-col gap-2 w-80">
             <AnimatePresence>
               {toasts.map((toast) => (
@@ -742,62 +791,126 @@ export const Profile = () => {
         ))}
       </div>
 
-      <Card className="p-6 border-slate-200/50 dark:border-slate-800/50 overflow-x-auto">
-        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-4 border-b border-slate-100 dark:border-slate-800 min-w-max">
-          <div>
-            <h3 className="font-extrabold text-lg text-slate-900 dark:text-white my-0 flex items-center gap-2">
-              <Activity className="w-5 h-5 text-violet-500" /> Contribution Activity
-            </h3>
-            <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
-              Verified GitHub commits mapped chronologically over the last 16 weeks.
-            </p>
-          </div>
-          <div className="text-right">
-            <span className="block text-xl font-black text-slate-900 dark:text-white leading-none">
-              {heatmap.total.toLocaleString()}
-            </span>
-            <span className="text-[10px] text-slate-400 font-bold uppercase mt-1 block">
-              Total Contributions
-            </span>
-          </div>
-        </div>
-
-        <div className="mt-6 flex flex-col items-start min-w-max">
-          <div className="flex gap-1">
-            <div className="grid grid-rows-7 gap-1 pr-2 text-[9px] font-bold text-slate-400">
-              <span className="row-start-2 h-3 sm:h-4 flex items-center justify-end">Mon</span>
-              <span className="row-start-4 h-3 sm:h-4 flex items-center justify-end">Wed</span>
-              <span className="row-start-6 h-3 sm:h-4 flex items-center justify-end">Fri</span>
+      {/* NEW SECTION: Two Heatmaps Side-by-Side */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        
+        {/* 1. GitHub Contributions Heatmap */}
+        <Card className="p-6 border-slate-200/50 dark:border-slate-800/50 overflow-x-auto flex flex-col">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-4 border-b border-slate-100 dark:border-slate-800 min-w-max">
+            <div>
+              <h3 className="font-extrabold text-lg text-slate-900 dark:text-white my-0 flex items-center gap-2">
+                <Github className="w-5 h-5 text-emerald-500" /> GitHub Activity
+              </h3>
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+                Verified repository commits over the last 16 weeks.
+              </p>
             </div>
+            <div className="text-right">
+              <span className="block text-xl font-black text-slate-900 dark:text-white leading-none">
+                {githubHeatmap.total.toLocaleString()}
+              </span>
+              <span className="text-[10px] text-slate-400 font-bold uppercase mt-1 block">
+                Total Commits
+              </span>
+            </div>
+          </div>
 
+          <div className="mt-6 flex flex-col items-start min-w-max flex-1">
             <div className="flex gap-1">
-              {heatmap.grid.map((week, wIdx) => (
-                <div key={wIdx} className="flex flex-col gap-1">
-                  {week.map((day, dIdx) => (
-                    <div
-                      key={`${wIdx}-${dIdx}`}
-                      className={`w-3 h-3 sm:w-4 sm:h-4 rounded-sm ${getIntensityColor(day.intensity)} transition-colors hover:ring-2 ring-slate-400/50 cursor-crosshair`}
-                      title={`${day.count > 0 ? day.count : "No"} contributions ${day.daysAgo === 0 ? "today" : `${day.daysAgo} days ago`}`}
-                    />
-                  ))}
-                </div>
-              ))}
+              <div className="grid grid-rows-7 gap-1 pr-2 text-[9px] font-bold text-slate-400">
+                <span className="row-start-2 h-3 sm:h-4 flex items-center justify-end">Mon</span>
+                <span className="row-start-4 h-3 sm:h-4 flex items-center justify-end">Wed</span>
+                <span className="row-start-6 h-3 sm:h-4 flex items-center justify-end">Fri</span>
+              </div>
+
+              <div className="flex gap-1">
+                {githubHeatmap.grid.map((week, wIdx) => (
+                  <div key={`gh-${wIdx}`} className="flex flex-col gap-1">
+                    {week.map((day, dIdx) => (
+                      <div
+                        key={`gh-${wIdx}-${dIdx}`}
+                        className={`w-3 h-3 sm:w-4 sm:h-4 rounded-sm ${getGithubIntensityColor(day.intensity)} transition-colors hover:ring-2 ring-slate-400/50 cursor-crosshair`}
+                        title={`${day.count > 0 ? day.count : "No"} commits ${day.daysAgo === 0 ? "today" : `${day.daysAgo} days ago`}`}
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-auto pt-4 flex items-center justify-end w-full gap-2 text-[10px] font-bold text-slate-400">
+              <span>Less</span>
+              <div className="flex gap-1">
+                <div className="w-3 h-3 rounded-sm bg-slate-100 dark:bg-slate-800/50" />
+                <div className="w-3 h-3 rounded-sm bg-emerald-300/40 dark:bg-emerald-300/40" />
+                <div className="w-3 h-3 rounded-sm bg-emerald-400/60 dark:bg-emerald-400/60" />
+                <div className="w-3 h-3 rounded-sm bg-emerald-500/80 dark:bg-emerald-500/80" />
+                <div className="w-3 h-3 rounded-sm bg-emerald-600 dark:bg-emerald-500" />
+              </div>
+              <span>More</span>
+            </div>
+          </div>
+        </Card>
+
+        {/* 2. RankerHub Internal Platform Heatmap */}
+        <Card className="p-6 border-slate-200/50 dark:border-slate-800/50 overflow-x-auto flex flex-col">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-4 border-b border-slate-100 dark:border-slate-800 min-w-max">
+            <div>
+              <h3 className="font-extrabold text-lg text-slate-900 dark:text-white my-0 flex items-center gap-2">
+                <Zap className="w-5 h-5 text-violet-500" /> Platform Activity
+              </h3>
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+                Internal interactions, check-ins, and CodingVerse solves.
+              </p>
+            </div>
+            <div className="text-right">
+              <span className="block text-xl font-black text-slate-900 dark:text-white leading-none">
+                {platformHeatmap.total.toLocaleString()}
+              </span>
+              <span className="text-[10px] text-slate-400 font-bold uppercase mt-1 block">
+                Platform Events
+              </span>
             </div>
           </div>
 
-          <div className="mt-4 flex items-center justify-end w-full gap-2 text-[10px] font-bold text-slate-400">
-            <span>Less</span>
+          <div className="mt-6 flex flex-col items-start min-w-max flex-1">
             <div className="flex gap-1">
-              <div className="w-3 h-3 rounded-sm bg-slate-100 dark:bg-slate-800/50" />
-              <div className="w-3 h-3 rounded-sm bg-violet-300/40 dark:bg-violet-300/40" />
-              <div className="w-3 h-3 rounded-sm bg-violet-400/60 dark:bg-violet-400/60" />
-              <div className="w-3 h-3 rounded-sm bg-violet-500/80 dark:bg-violet-500/80" />
-              <div className="w-3 h-3 rounded-sm bg-violet-600 dark:bg-violet-500" />
+              <div className="grid grid-rows-7 gap-1 pr-2 text-[9px] font-bold text-slate-400">
+                <span className="row-start-2 h-3 sm:h-4 flex items-center justify-end">Mon</span>
+                <span className="row-start-4 h-3 sm:h-4 flex items-center justify-end">Wed</span>
+                <span className="row-start-6 h-3 sm:h-4 flex items-center justify-end">Fri</span>
+              </div>
+
+              <div className="flex gap-1">
+                {platformHeatmap.grid.map((week, wIdx) => (
+                  <div key={`plat-${wIdx}`} className="flex flex-col gap-1">
+                    {week.map((day, dIdx) => (
+                      <div
+                        key={`plat-${wIdx}-${dIdx}`}
+                        className={`w-3 h-3 sm:w-4 sm:h-4 rounded-sm ${getPlatformIntensityColor(day.intensity)} transition-colors hover:ring-2 ring-slate-400/50 cursor-crosshair`}
+                        title={`${day.count > 0 ? day.count : "No"} interactions ${day.daysAgo === 0 ? "today" : `${day.daysAgo} days ago`}`}
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
             </div>
-            <span>More</span>
+
+            <div className="mt-auto pt-4 flex items-center justify-end w-full gap-2 text-[10px] font-bold text-slate-400">
+              <span>Less</span>
+              <div className="flex gap-1">
+                <div className="w-3 h-3 rounded-sm bg-slate-100 dark:bg-slate-800/50" />
+                <div className="w-3 h-3 rounded-sm bg-violet-300/40 dark:bg-violet-300/40" />
+                <div className="w-3 h-3 rounded-sm bg-violet-400/60 dark:bg-violet-400/60" />
+                <div className="w-3 h-3 rounded-sm bg-violet-500/80 dark:bg-violet-500/80" />
+                <div className="w-3 h-3 rounded-sm bg-violet-600 dark:bg-violet-500" />
+              </div>
+              <span>More</span>
+            </div>
           </div>
-        </div>
-      </Card>
+        </Card>
+
+      </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         
@@ -935,6 +1048,7 @@ export const Profile = () => {
               if (badge.id === "b2" && gitRankPoints >= 100) unlocked = true;
               if (badge.id === "b3" && streak >= 10) unlocked = true;
               if (badge.id === "b4" && codingVersePoints >= 100) unlocked = true;
+              if (badge.id === "b5" && referralPoints >= 1000) unlocked = true;
 
               return (
                 <div

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -55,6 +55,12 @@ export const Profile = () => {
 
   const editDropdownRef = useRef(null);
 
+  // 1. Profile Real Heatmap State (Issue #205 Fix)
+  const [heatmap, setHeatmap] = useState({
+    grid: Array.from({ length: 16 }, () => Array(7).fill({ intensity: 0, daysAgo: 0, count: 0 })),
+    total: 0
+  });
+
   const filteredColleges = useMemo(() => {
     if (collegeSearch.trim() === "" || collegeSearch === "Other") {
       return collegesList;
@@ -124,7 +130,6 @@ export const Profile = () => {
       return;
     }
 
-    // Age validation (13+ years and not in the future)
     const today = new Date().toISOString().split("T")[0];
     if (editDob > today) {
       setEditError("Date of birth cannot be in the future.");
@@ -237,6 +242,67 @@ export const Profile = () => {
     fetchRank();
   }, [userData]);
 
+  // Fetch REAL Profile Heatmap Data replacing the old useMemo fake math (Issue #205)
+  useEffect(() => {
+    const fetchProfileHeatmap = async () => {
+      const username = userData?.githubUsername;
+      if (!username) return;
+
+      try {
+        const res = await fetch(`https://github-contributions-api.jogruber.de/v4/${username}?y=last`);
+        if (!res.ok) throw new Error("API Limit");
+        
+        const data = await res.json();
+        const contributions = data.contributions || [];
+
+        // We need exactly 112 days to form 16 weeks * 7 days
+        const last112 = contributions.slice(-112);
+        let totalActivity = 0;
+        const grid = [];
+        let currentWeek = [];
+
+        last112.forEach((day, index) => {
+          const c = day.count;
+          totalActivity += c;
+          let intensity = 0;
+          
+          if (c > 0 && c <= 2) intensity = 1;
+          else if (c > 2 && c <= 5) intensity = 2;
+          else if (c > 5 && c <= 9) intensity = 3;
+          else if (c > 9) intensity = 4;
+
+          const daysAgo = 111 - index; 
+
+          currentWeek.push({ intensity, daysAgo, count: c });
+
+          if (currentWeek.length === 7) {
+            grid.push(currentWeek);
+            currentWeek = [];
+          }
+        });
+
+        // Pad if account has fewer than 112 days of history
+        if (grid.length < 16) {
+          const diff = 16 - grid.length;
+          const padWeek = Array(7).fill({ intensity: 0, daysAgo: 0, count: 0 });
+          const padGrid = Array(diff).fill(padWeek);
+          grid.unshift(...padGrid);
+        }
+
+        setHeatmap({ grid, total: totalActivity });
+      } catch (err) {
+        console.error("Profile heatmap fetch error:", err);
+        // Fallback to strict zeros
+        setHeatmap({
+          grid: Array.from({ length: 16 }, () => Array(7).fill({ intensity: 0, daysAgo: 0, count: 0 })),
+          total: 0
+        });
+      }
+    };
+
+    fetchProfileHeatmap();
+  }, [userData?.githubUsername]);
+
   const handleShareProfile = () => {
     const code = userData?.referralCode || "NEWCODE";
     navigator.clipboard.writeText(code);
@@ -290,7 +356,6 @@ export const Profile = () => {
       
       updateData.updatedAt = new Date().toISOString();
       
-      // Use Atomic Batch Write instead of updateDoc
       const batch = writeBatch(db);
       batch.update(userRef, updateData);
       await batch.commit();
@@ -328,7 +393,6 @@ export const Profile = () => {
       const isEnabling = !userData?.privateRepoSyncEnabled;
       const userRef = doc(db, "users", user.uid);
       
-      // Use Atomic Batch Write instead of updateDoc
       const batch = writeBatch(db);
       batch.update(userRef, { privateRepoSyncEnabled: isEnabling });
       await batch.commit();
@@ -357,43 +421,6 @@ export const Profile = () => {
     { label: "Referral Points", value: referralPoints, color: "bg-emerald-500" }
   ];
   const earnedPointsTotal = pointsEngines.reduce((sum, engine) => sum + Math.max(engine.value, 0), 0);
-
-  const heatmap = useMemo(() => {
-    const weeks = 16;
-    const daysPerWeek = 7;
-    const data = [];
-    
-    const seed = streak || 1;
-    let activityTotal = 0;
-
-    for (let w = 0; w < weeks; w++) {
-      const weekData = [];
-      for (let d = 0; d < daysPerWeek; d++) {
-        const daysAgo = ((weeks - 1 - w) * daysPerWeek) + (daysPerWeek - 1 - d);
-        let intensity; 
-        
-        if (daysAgo < streak) {
-           intensity = (daysAgo % 3) + 2; 
-        } else if (daysAgo > 111) {
-           intensity = 0; 
-        } else {
-           const pseudoRandom = Math.abs(Math.sin(daysAgo * seed) * 10000);
-           const normalized = pseudoRandom - Math.floor(pseudoRandom);
-           if (normalized > 0.8) intensity = 4;
-           else if (normalized > 0.6) intensity = 3;
-           else if (normalized > 0.4) intensity = 2;
-           else if (normalized > 0.2) intensity = 1;
-           else intensity = 0;
-        }
-        
-        activityTotal += intensity;
-        weekData.push({ intensity, daysAgo });
-      }
-      data.push(weekData);
-    }
-    
-    return { grid: data, total: activityTotal * 3 }; 
-  }, [streak]);
 
   const getIntensityColor = (intensity) => {
     switch(intensity) {
@@ -657,18 +684,18 @@ export const Profile = () => {
             ))}
           </div>
           {/* Toast Stack */}
-<div className="fixed bottom-6 right-5 z-50 flex flex-col gap-2 w-80">
-  <AnimatePresence>
-    {toasts.map((toast) => (
-      <Toast
-        key={toast.id}
-        message={toast.message}
-        type={toast.type}
-        onClose={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}
-      />
-    ))}
-  </AnimatePresence>
-</div>
+          <div className="fixed bottom-6 right-5 z-50 flex flex-col gap-2 w-80">
+            <AnimatePresence>
+              {toasts.map((toast) => (
+                <Toast
+                  key={toast.id}
+                  message={toast.message}
+                  type={toast.type}
+                  onClose={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}
+                />
+              ))}
+            </AnimatePresence>
+          </div>
         </div>
       </Card>
 
@@ -722,7 +749,7 @@ export const Profile = () => {
               <Activity className="w-5 h-5 text-violet-500" /> Contribution Activity
             </h3>
             <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
-              Combined GitHub commits and RankerHub platform activity over the last 16 weeks.
+              Verified GitHub commits mapped chronologically over the last 16 weeks.
             </p>
           </div>
           <div className="text-right">
@@ -750,7 +777,7 @@ export const Profile = () => {
                     <div
                       key={`${wIdx}-${dIdx}`}
                       className={`w-3 h-3 sm:w-4 sm:h-4 rounded-sm ${getIntensityColor(day.intensity)} transition-colors hover:ring-2 ring-slate-400/50 cursor-crosshair`}
-                      title={`${day.intensity > 0 ? day.intensity * 3 : "No"} contributions ${day.daysAgo === 0 ? "today" : `${day.daysAgo} days ago`}`}
+                      title={`${day.count > 0 ? day.count : "No"} contributions ${day.daysAgo === 0 ? "today" : `${day.daysAgo} days ago`}`}
                     />
                   ))}
                 </div>
@@ -930,7 +957,7 @@ export const Profile = () => {
                   </div>
 
                   <div>
-                    <h4 className="font-extrabold text-slate-900 dark:text-slate-200 leading-tight flex items-center gap-1">
+                    <h4 className="font-extrabold text-slate-900 dark:text-white leading-tight flex items-center gap-1">
                       {badge.name}
                       {!unlocked && <span className="text-[8px] font-bold text-slate-400 bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded">Locked</span>}
                     </h4>


### PR DESCRIPTION
### Description
Resolves #204 by introducing a secondary Activity Heatmap on the user profile to visualize internal platform engagement (e.g., CodingVerse solves, login streaks) distinct from their GitHub contributions.

**Key Additions:**
* **Side-by-Side Analytics:** Restructured the Activity Card section into a `grid-cols-2` layout, displaying the legacy GitHub Heatmap on the left and the new Platform Activity Heatmap on the right.
* **Color Segregation:** Shifted the GitHub activity graph to an `emerald` color scale (matching native GitHub UI) while establishing a distinct `violet/indigo` gradient mapping for internal platform logs.
* **Dynamic Log Aggregation:** Developed a `useMemo` computation loop to parse the `userData.platformActivityLogs` array. It dynamically maps timestamps into frequency counts across the standard 16-week grid matrix.

Fixes #204