### PR TITLE
Remove GitHub access tokens from userData to prevent Firestore storage (Issue #275)

### DIFF
--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -103,16 +103,19 @@ export const signInWithGitHub = async (requestRepoScope = false) => {
     
     const credential = GithubAuthProvider.credentialFromResult(result);
     const accessToken = credential.accessToken;
-    
+
+    // SECURITY NOTE: Never include access tokens in userData or Firestore
+    // Tokens are sensitive credentials that should only exist in memory
+    // and only be used in secure, server-side operations
     const userData = {
       uid: user.uid,
       email: user.email,
       displayName: user.displayName,
       photoURL: user.photoURL,
-      githubAccessToken: accessToken,
       lastLogin: new Date().toISOString(),
+      // githubAccessToken NOT included - never store tokens in Firestore
     };
-    
+
     return { user, accessToken, userData, result }; 
   } catch (error) {
     console.error("GitHub sign-in error:", error);


### PR DESCRIPTION
## Summary

Removes GitHub OAuth access tokens from userData objects to prevent accidental storage in Firestore database, violating secret management principles.

## Problem

GitHub OAuth tokens included in userData object could potentially be stored in Firestore if code changes occur. This violates security principles:
- Tokens should never be persisted to databases
- Increases attack surface from database breaches
- Violates OWASP and PCI-DSS guidelines
- Makes token rotation impossible
- No audit trail for token access

## Solution

Removed githubAccessToken from userData object:
- Tokens kept in memory only during session
- userData object no longer contains credentials
- Added security comments explaining token handling
- Ensures tokens never reach Firestore

## Changes

- Modified `src/lib/firebase.js` signInWithGitHub function
- Removed githubAccessToken from userData construction
- Added security documentation comments

## Security Benefits

Prevents Credential Exposure:
- Tokens never included in stored user objects
- Memory-only approach prevents database leaks
- No risk of credential exposure from backups

Reduces Attack Surface:
- Database breach cannot expose tokens
- Tokens cannot be recovered from backups
- Limits damage from potential Firestore access

## Testing Strategy

- Verify login still works with token in memory
- Check userData doesn't contain token
- Verify API calls still use token properly
- Test token is cleared on logout
- Verify no credentials in Firestore

## Files Modified

- Modified: src/lib/firebase.js (removed token from userData)

Fixes #275