### PR TITLE
feat: implement followers-only rankings in friends section (fixes #202)

### DIFF
--- a/src/components/friends/DeveloperCard.jsx
+++ b/src/components/friends/DeveloperCard.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { ArrowUpRight, Check, UserPlus, UsersRound } from "lucide-react";
+import { ArrowUpRight, Check, UserPlus, UsersRound, Trophy } from "lucide-react";
 import Card from "../ui/Card";
 import GradientButton from "../ui/GradientButton";
 
-export const DeveloperCard = ({ developer, isFollowing, onToggleFollow, compact = false }) => {
+export const DeveloperCard = ({ developer, isFollowing, onToggleFollow, compact = false, showPoints = false }) => {
   return (
     <Card className={`${compact ? "p-4" : "p-5"} h-full flex flex-col gap-4`}>
       <div className="flex items-start gap-4">
@@ -75,6 +75,12 @@ export const DeveloperCard = ({ developer, isFollowing, onToggleFollow, compact 
             <UsersRound className="w-3.5 h-3.5 text-violet-500" />
             {developer.mutualFriends} mutual friends
           </span>
+          {showPoints && (
+            <span className="flex items-center gap-1.5">
+              <Trophy className="w-3.5 h-3.5 text-yellow-500" />
+              {developer.totalPoints?.toLocaleString() || 0} XP
+            </span>
+          )}
           {!compact && <span className="block truncate max-w-[220px]">{developer.activity}</span>}
         </div>
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -137,7 +137,7 @@ export const AuthProvider = ({ children }) => {
               setLoading(false);
             }, null);
           }
-        }, (error) => {
+        }, (_error) => {
           setLoading(false);
         });
 

--- a/src/pages/Friends.jsx
+++ b/src/pages/Friends.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Activity, HeartHandshake, UserCheck, UserPlus, UsersRound } from "lucide-react";
+import { Activity, HeartHandshake, Trophy, UserCheck, UserPlus, UsersRound } from "lucide-react";
 import SectionHeader from "../components/ui/SectionHeader";
 import Card from "../components/ui/Card";
 import DeveloperCard from "../components/friends/DeveloperCard";
@@ -16,11 +16,13 @@ import {
 
 const tabs = [
   { id: "friends", label: "Friends", path: "/dashboard/friends", icon: HeartHandshake },
+  { id: "leaderboard", label: "Leaderboard", path: "/dashboard/friends/leaderboard", icon: Trophy },
   { id: "followers", label: "Followers", path: "/dashboard/friends/followers", icon: UsersRound },
   { id: "following", label: "Following", path: "/dashboard/friends/following", icon: UserCheck }
 ];
 
 const getActiveTab = (pathname) => {
+  if (pathname.endsWith("/leaderboard")) return "leaderboard";
   if (pathname.endsWith("/followers")) return "followers";
   if (pathname.endsWith("/following")) return "following";
   return "friends";
@@ -29,7 +31,7 @@ const getActiveTab = (pathname) => {
 export const Friends = () => {
   const location = useLocation();
   const activeTab = getActiveTab(location.pathname);
-  const { user: currentUser } = useAuth();
+  const { user: currentUser, userData } = useAuth();
 
   const [developers, setDevelopers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -76,9 +78,42 @@ export const Friends = () => {
     [developers, followingIds, followerIds]
   );
 
-  const activeDevelopers = connections[activeTab];
+  // Build a leaderboard from the user's network (followers + following, deduplicated), including the current user
+  const leaderboardStandings = useMemo(() => {
+    const networkMap = new Map();
+
+    // Add all followers and following to the map (deduplicates by id)
+    [...connections.followers, ...connections.following].forEach((dev) => {
+      if (!networkMap.has(dev.id)) {
+        networkMap.set(dev.id, dev);
+      }
+    });
+
+    // Include the current user in the standings
+    if (currentUser?.uid) {
+      networkMap.set(currentUser.uid, {
+        id: currentUser.uid,
+        name: userData?.name || userData?.displayName || userData?.githubUsername || currentUser.displayName || "You",
+        username: userData?.githubUsername || currentUser.uid,
+        avatar: userData?.avatar || userData?.photoURL || currentUser.photoURL || `https://ui-avatars.com/api/?name=You&background=random`,
+        role: userData?.role || "Developer",
+        bio: userData?.bio || "That's you!",
+        tags: userData?.skills || ["Developer"],
+        mutualFriends: 0,
+        online: true,
+        activity: "Currently active",
+        totalPoints: userData?.points?.totalPoints || 0
+      });
+    }
+
+    // Sort descending by totalPoints
+    return Array.from(networkMap.values()).sort((a, b) => (b.totalPoints || 0) - (a.totalPoints || 0));
+  }, [connections.followers, connections.following, currentUser, userData]);
+
+  const activeDevelopers = activeTab === "leaderboard" ? leaderboardStandings : connections[activeTab];
   const tabCopy = {
     friends: "Developers who follow you back and collaborate with you across RankerHub.",
+    leaderboard: "Your network ranked by total XP — see where you stand among your connections.",
     followers: "Developers tracking your public progress, badges, and challenge activity.",
     following: "Developers whose rankings, activity, and learning notes you follow."
   };
@@ -168,14 +203,32 @@ export const Friends = () => {
           </div>
 
           {activeDevelopers.length > 0 ? (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-              {activeDevelopers.map((developer) => (
-                <DeveloperCard
-                  key={developer.id}
-                  developer={developer}
-                  isFollowing={followingIds.includes(developer.id)}
-                  onToggleFollow={handleToggleFollow}
-                />
+            <div className={activeTab === "leaderboard" ? "space-y-3" : "grid grid-cols-1 lg:grid-cols-2 gap-4"}>
+              {activeDevelopers.map((developer, index) => (
+                <div key={developer.id} className={activeTab === "leaderboard" ? "flex items-stretch gap-3" : ""}>
+                  {activeTab === "leaderboard" && (
+                    <div className={`flex-shrink-0 w-10 flex flex-col items-center justify-center rounded-xl font-black text-sm ${
+                      index === 0
+                        ? "bg-gradient-to-b from-yellow-400 to-amber-500 text-white shadow-[0_4px_15px_rgba(245,158,11,0.3)]"
+                        : index === 1
+                        ? "bg-gradient-to-b from-slate-300 to-slate-400 text-white"
+                        : index === 2
+                        ? "bg-gradient-to-b from-amber-600 to-amber-700 text-white"
+                        : "bg-white/70 dark:bg-slate-900/70 border border-slate-200/50 dark:border-slate-800/50 text-slate-500 dark:text-slate-400"
+                    }`}>
+                      #{index + 1}
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <DeveloperCard
+                      developer={developer}
+                      isFollowing={followingIds.includes(developer.id)}
+                      onToggleFollow={handleToggleFollow}
+                      showPoints={activeTab === "leaderboard"}
+                      compact={activeTab === "leaderboard"}
+                    />
+                  </div>
+                </div>
               ))}
             </div>
           ) : (
@@ -183,7 +236,9 @@ export const Friends = () => {
               <UsersRound className="w-10 h-10 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
               <h3 className="font-black text-slate-900 dark:text-white my-0">No developers here yet</h3>
               <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-                Follow developers from suggestions to grow this section instantly.
+                {activeTab === "leaderboard"
+                  ? "Follow other developers to populate your Friends Leaderboard."
+                  : "Follow developers from suggestions to grow this section instantly."}
               </p>
             </Card>
           )}

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -9,7 +9,6 @@ import Card from "../components/ui/Card";
 import SectionHeader from "../components/ui/SectionHeader";
 import GradientButton from "../components/ui/GradientButton";
 import axios from "axios";
-import { TokenManager } from "../utils/tokenManager";
 
 export const GitRank = () => {
   const { user, userData, fetchGitHubStats, login } = useAuth();

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -150,7 +150,7 @@ export const Onboarding = () => {
       setIsLoading(false);
       return;
     }
-    if (!selectedCollege || !collegesList.includes(selectedCollege) || collegeSearch !== selectedCollege) {
+    if (!selectedCollege || selectedCollege !== collegeSearch || !collegesList.includes(selectedCollege)) {
       setError("Please select a valid college from the searchable dropdown list.");
       setIsLoading(false);
       return;

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from "react";
 import domtoimage from 'dom-to-image-more';
+import { useParams } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import LottiePlayer from "../components/ui/LottiePlayer";
 import {
@@ -21,7 +22,7 @@ import {
   Zap
 } from "lucide-react";
 import { Github, Linkedin, Instagram } from "../components/ui/Icons";
-import { query, collection, where, getCountFromServer, doc, getDoc, writeBatch, updateDoc } from "firebase/firestore";
+import { query, collection, where, getCountFromServer, doc, getDoc, writeBatch, updateDoc, getDocs } from "firebase/firestore";
 import { db } from "../lib/firebase";
 import { useAuth } from "../context/AuthContext";
 import successTick from "../assets/animations/succes_tick.json";
@@ -29,12 +30,19 @@ import trophyAnimation from "../assets/animations/trophy.json";
 import { systemBadges } from "../constants";
 import Card from "../components/ui/Card";
 import SectionHeader from "../components/ui/SectionHeader";
+import Loader from "../components/ui/Loader";
 import GradientButton from "../components/ui/GradientButton";
 import Toast from "../components/ui/Toast";
 import collegesList from "../data/colleges.json";
 
 export const Profile = () => {
-  const { userData, user, setUserData, syncGitHubData } = useAuth();
+  const { userData: authUserData, user, setUserData, syncGitHubData } = useAuth();
+  const { username } = useParams();
+  const [publicProfile, setPublicProfile] = useState(null);
+  const [loadingPublicProfile, setLoadingPublicProfile] = useState(!!username);
+
+  const isOwnProfile = !username || username === authUserData?.githubUsername || username === user?.uid;
+  
   // Utility to escape text for embedding in XML/SVG
   const escapeXml = (unsafe) => {
     if (unsafe == null) return '';
@@ -45,6 +53,41 @@ export const Profile = () => {
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&apos;');
   };
+  
+  useEffect(() => {
+    const fetchProfile = async () => {
+      if (isOwnProfile) {
+        setPublicProfile(null);
+        setLoadingPublicProfile(false);
+        return;
+      }
+      setLoadingPublicProfile(true);
+      try {
+        const q1 = query(collection(db, "users"), where("githubUsername", "==", username));
+        const snapshot1 = await getDocs(q1);
+        if (!snapshot1.empty) {
+          setPublicProfile(snapshot1.docs[0].data());
+        } else {
+          const docRef = doc(db, "users", username);
+          const docSnap = await getDoc(docRef);
+          if (docSnap.exists()) {
+            setPublicProfile(docSnap.data());
+          } else {
+            setPublicProfile(null);
+          }
+        }
+      } catch (error) {
+        console.error("Error fetching public profile:", error);
+        setPublicProfile(null);
+      }
+      setLoadingPublicProfile(false);
+    };
+    if (username && (authUserData || !user)) {
+       fetchProfile();
+    }
+  }, [username, isOwnProfile, authUserData, user]);
+
+  const userData = isOwnProfile ? authUserData : publicProfile;
   const [copied, setCopied] = useState(false);
   const [rank, setRank] = useState("Loading...");
   const [toasts, setToasts] = useState([]);
@@ -991,19 +1034,23 @@ export const Profile = () => {
               <span className="text-xs font-medium hidden sm:inline">{social.name}</span>
             </div>
           )}
-          <button
-            onClick={() => {
-              setEditingSocial(social.id);
-              setEditValue(displayValue || "");
-            }}
-            className="absolute -top-1 -right-1 p-0.5 rounded-full bg-violet-500 text-white opacity-0 group-hover:opacity-100 transition-opacity"
-            title={`Edit ${social.name}`}
-          >
-            <Edit2 className="w-2.5 h-2.5" />
-          </button>
+          {isOwnProfile && (
+            <button
+              onClick={() => {
+                setEditingSocial(social.id);
+                setEditValue(displayValue || "");
+              }}
+              className="absolute -top-1 -right-1 p-0.5 rounded-full bg-violet-500 text-white opacity-0 group-hover:opacity-100 transition-opacity"
+              title={`Edit ${social.name}`}
+            >
+              <Edit2 className="w-2.5 h-2.5" />
+            </button>
+          )}
         </div>
       );
     }
+
+    if (!isOwnProfile) return null;
 
     return (
       <button
@@ -1019,23 +1066,44 @@ export const Profile = () => {
     );
   };
 
+  if (loadingPublicProfile) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader />
+      </div>
+    );
+  }
+
+  if (!userData) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh]">
+        <h2 className="text-2xl font-black text-slate-900 dark:text-white">Profile not found</h2>
+        <p className="text-slate-500 mt-2">The developer you are looking for does not exist.</p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-8">
       <SectionHeader
-        title="Developer Profile"
-        subtitle="Manage your public links, view achievements, and review earned badges."
+        title={isOwnProfile ? "Developer Profile" : `${userData?.name || "Developer"}'s Profile`}
+        subtitle={isOwnProfile ? "Manage your public links, view achievements, and review earned badges." : `View ${userData?.name || "this developer"}'s achievements and badges.`}
         badge="Verified Account"
         badgeColor="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20"
       >
-        <GradientButton onClick={handleOpenEditModal} variant="secondary" className="py-2.5 px-4 text-xs">
-          Edit Profile
-        </GradientButton>
-        <GradientButton onClick={handleShareProfile} className="py-2.5 px-4 text-xs">
-          {copied ? "Code Copied!" : "Copy Referral Code"}
-        </GradientButton>
-        <GradientButton onClick={handleDownloadProfileCard} className="py-2.5 px-4 text-xs">
-          Download Profile Card
-        </GradientButton>
+        {isOwnProfile && (
+          <>
+            <GradientButton onClick={handleOpenEditModal} variant="secondary" className="py-2.5 px-4 text-xs">
+              Edit Profile
+            </GradientButton>
+            <GradientButton onClick={handleShareProfile} className="py-2.5 px-4 text-xs">
+              {copied ? "Code Copied!" : "Copy Referral Code"}
+            </GradientButton>
+            <GradientButton onClick={handleDownloadProfileCard} className="py-2.5 px-4 text-xs">
+              Download Profile Card
+            </GradientButton>
+          </>
+        )}
       </SectionHeader>
 
       <Card ref={profileCardRef} className="p-8 relative overflow-hidden flex flex-col md:flex-row items-center gap-8 border-slate-200/50 dark:border-slate-800/50">
@@ -1080,9 +1148,11 @@ export const Profile = () => {
             <span className="flex items-center gap-1">
               <Calendar className="w-4 h-4 text-slate-400" /> Joined {userData?.createdAt ? new Date(userData.createdAt).toLocaleDateString(undefined, {month: 'long', year: 'numeric'}) : "May 2026"}
             </span>
-            <span className="flex items-center gap-1 text-violet-500">
-              🎫 Referral Code: <span className="font-extrabold bg-violet-500/10 px-2 py-0.5 rounded-full select-all">{userData?.referralCode || "N/A"}</span>
-            </span>
+            {isOwnProfile && (
+              <span className="flex items-center gap-1 text-violet-500">
+                🎫 Referral Code: <span className="font-extrabold bg-violet-500/10 px-2 py-0.5 rounded-full select-all">{userData?.referralCode || "N/A"}</span>
+              </span>
+            )}
           </div>
 
           <div className="flex justify-center md:justify-start items-center gap-3 pt-2 flex-wrap">
@@ -1107,32 +1177,34 @@ export const Profile = () => {
         </div>
       </Card>
 
-      <Card className="mb-6 p-6 flex flex-col sm:flex-row items-center justify-between gap-4 border-slate-200/50 dark:border-slate-800/50">
-        <div>
-          <h3 className="font-extrabold text-lg text-slate-900 dark:text-white my-0 flex items-center gap-2">
-            <Github className="w-5 h-5 text-slate-700 dark:text-slate-300" /> Private Repository Sync
-          </h3>
-          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 font-medium">
-            Enable indexing for private repositories to earn points for your private commits, PRs, and reviews.
-          </p>
-        </div>
-        
-        <button
-          onClick={handlePrivateSyncToggle}
-          className={`relative inline-flex h-7 w-14 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 flex-shrink-0 ${
-            userData?.privateRepoSyncEnabled ? 'bg-violet-500' : 'bg-slate-300 dark:bg-slate-700'
-          }`}
-          role="switch"
-          aria-checked={userData?.privateRepoSyncEnabled}
-        >
-          <span className="sr-only">Enable Private Repo Sync</span>
-          <span
-            className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-sm transition-transform ${
-              userData?.privateRepoSyncEnabled ? 'translate-x-8' : 'translate-x-1'
+      {isOwnProfile && (
+        <Card className="mb-6 p-6 flex flex-col sm:flex-row items-center justify-between gap-4 border-slate-200/50 dark:border-slate-800/50">
+          <div>
+            <h3 className="font-extrabold text-lg text-slate-900 dark:text-white my-0 flex items-center gap-2">
+              <Github className="w-5 h-5 text-slate-700 dark:text-slate-300" /> Private Repository Sync
+            </h3>
+            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 font-medium">
+              Enable indexing for private repositories to earn points for your private commits, PRs, and reviews.
+            </p>
+          </div>
+          
+          <button
+            onClick={handlePrivateSyncToggle}
+            className={`relative inline-flex h-7 w-14 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 flex-shrink-0 ${
+              userData?.privateRepoSyncEnabled ? 'bg-violet-500' : 'bg-slate-300 dark:bg-slate-700'
             }`}
-          />
-        </button>
-      </Card>
+            role="switch"
+            aria-checked={userData?.privateRepoSyncEnabled}
+          >
+            <span className="sr-only">Enable Private Repo Sync</span>
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-sm transition-transform ${
+                userData?.privateRepoSyncEnabled ? 'translate-x-8' : 'translate-x-1'
+              }`}
+            />
+          </button>
+        </Card>
+      )}
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
         {profileStats.map((stat, idx) => (

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -144,6 +144,7 @@ export const AppRoutes = () => {
           <Route path="/dashboard/codingverse" element={<CodingVerse />} />
           <Route path="/dashboard/codingowl" element={<CodingOwl />} />
           <Route path="/dashboard/friends" element={<Friends />} />
+          <Route path="/dashboard/friends/leaderboard" element={<Friends />} />
           <Route path="/dashboard/friends/followers" element={<Friends />} />
           <Route path="/dashboard/friends/following" element={<Friends />} />
           <Route path="/dashboard/profile" element={<Profile />} />

--- a/src/services/friendsService.js
+++ b/src/services/friendsService.js
@@ -2,8 +2,6 @@ import {
   collection, 
   getDocs, 
   doc, 
-  setDoc, 
-  deleteDoc, 
   onSnapshot, 
   query, 
   where, 

--- a/src/services/friendsService.js
+++ b/src/services/friendsService.js
@@ -34,7 +34,8 @@ export const fetchDevelopers = async () => {
         tags: data.skills || ["Developer"],
         mutualFriends: 0,
         online: false,
-        activity: "Recently joined RankerHub"
+        activity: "Recently joined RankerHub",
+        totalPoints: data.points?.totalPoints || 0
       };
     });
   } catch (error) {


### PR DESCRIPTION
## Description
This PR addresses issue #202 by implementing a mini-leaderboard in the Friends section that ranks the user's connections (followers and following) by their total points.

### Changes Made:
- **Leaderboard Tab (`Friends.jsx`)**: Added a new tab in the Friends section that aggregates the user's followers and following into a deduplicated list, inserts the current user, and sorts everyone descending by `totalPoints`.
- **Rank Badges**: Added visual indicators (gold/silver/bronze badges for the top 3 and numbered ranks for others) for standings.
- **Card UI Polish (`DeveloperCard.jsx`)**: 
  - Conditionally passed a `compact` prop to the developer card when on the leaderboard tab, shifting the layout to be more horizontal and space-efficient.
  - Added an XP indicator with a `Trophy` icon.
- **Profile Routing Fix (`Profile.jsx`)**: 
  - The `DeveloperCard` links to `/dashboard/profile/:username`. `Profile.jsx` previously ignored this URL parameter and only displayed the logged-in user's profile.
  - Implemented `useParams` to fetch and render the clicked developer's public profile dynamically.
  - Disabled editing actions and removed sensitive details (e.g., private repo sync toggle) when viewing someone else's public profile.

### Demo:

https://github.com/user-attachments/assets/e5aebbd7-5e6b-45e3-8c1b-993e4c327d4a


Closes #202
