### PR TITLE
Fix: College input validation bypass via state mismatch (Issue #264)

### DIFF
--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -150,8 +150,8 @@ export const Onboarding = () => {
       setIsLoading(false);
       return;
     }
-    if (!selectedCollege || !collegesList.includes(selectedCollege)) {
-      setError("Please select a college from the searchable dropdown list.");
+    if (!selectedCollege || !collegesList.includes(selectedCollege) || collegeSearch !== selectedCollege) {
+      setError("Please select a valid college from the searchable dropdown list.");
       setIsLoading(false);
       return;
     }


### PR DESCRIPTION


Fixes #264

## Description
This pull request addresses a high-severity security/validation bug where users could bypass the college selection validation by manipulating the search input. Previously, the form only validated the `selectedCollege` state, allowing a user to manually type an invalid college name in the search input while `selectedCollege` held a valid (or empty) value. This allowed invalid college entries to pass validation and be stored in the database.

## Changes Made
- Added a strict equality check (`collegeSearch !== selectedCollege`) during form submission in `src/pages/Onboarding.jsx`.
- If a user types a custom college name that does not match their dropdown selection, the form will correctly block submission and prompt the user to select a valid college from the searchable dropdown list.

## Proof of Fix
### Before Fix
- **Scenario:** User selects "Mumbai University" from the dropdown. `selectedCollege = "Mumbai University"`, `collegeSearch = "Mumbai University"`.
- User then manually types "Fake University" in the search box.
- `collegeSearch = "Fake University"`, but `selectedCollege = "Mumbai University"`.
- **Result:** The form submits successfully, saving a mismatched or unintended value, polluting the database.

### After Fix
- **Scenario:** User selects "Mumbai University" from the dropdown.
- User then manually types "Fake University" in the search box.
- When they click submit, the form checks `collegeSearch !== selectedCollege`.
- Since `"Fake University" !== "Mumbai University"`, validation fails correctly.
- **Result:** The user sees the error message `"Please select a valid college from the searchable dropdown list."` and the form submission is blocked.

This effectively ensures that only valid, explicitly selected items from the dropdown (or properly typed "Other" entries) can ever be submitted to the Firestore database.

Closes: #264 