### PR TITLE
docs: Add local Firebase emulator setup instructions (#311)

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,3 +1,4 @@
+
 # 🛠️ RankerHub Developer Environment Setup Guide
 
 Welcome to the RankerHub developer documentation! This guide will help you set up the project locally on your machine, connect it to your own Firebase development environment, and start contributing.
@@ -18,60 +19,56 @@ Before you begin, ensure you have the following installed:
 ## 🚀 Step 1: Clone and Install Dependencies
 
 1. Fork the repository on GitHub.
-2. Clone your forked repository:
+1. Clone your forked repository:
 
 ```bash
-git clone https://github.com/<your-username>/RankerHub.git
+git clone [https://github.com/](https://github.com/)<your-username>/RankerHub.git
 cd RankerHub
-```
+Install the required dependencies:
 
-3. Install the required dependencies:
-
-```bash
+Bash
 npm install
-```
-
----
-
-## 🔥 Step 2: Firebase Project Provisioning
-
+🔥 Step 2: Firebase Project Provisioning
 To prevent testing against the production database, create your own Firebase project for local development.
 
-### Create a Firebase Project
+Create a Firebase Project
+Open the Firebase Console.
 
-1. Open the Firebase Console.
-2. Click **Add Project**.
-3. Name it something like `rankerhub-dev`.
-4. Complete the setup process.
+Click Add Project.
 
-### Configure Firestore
+Name it something like rankerhub-dev.
 
-1. Navigate to **Build → Firestore Database**.
-2. Click **Create Database**.
-3. Select **Start in Test Mode**.
+Complete the setup process.
 
-### Configure Authentication
+Configure Firestore
+Navigate to Build → Firestore Database.
 
-1. Navigate to **Build → Authentication**.
-2. Click **Get Started**.
-3. Enable the **GitHub** sign-in provider.
+Click Create Database.
 
-> **Note:** You will need to create a GitHub OAuth App in GitHub Developer Settings and provide the generated Client ID and Client Secret.
+Select Start in Test Mode.
 
-### Create a Web App
+Configure Authentication
+Navigate to Build → Authentication.
 
-1. Open **Project Settings** (⚙️ icon).
-2. Under **General**, scroll down to **Your Apps**.
-3. Click **Add App → Web App**.
-4. Copy the Firebase configuration values.
+Click Get Started.
 
----
+Enable the GitHub sign-in provider.
 
-## 🔑 Step 3: Environment Variables
+Note: You will need to create a GitHub OAuth App in GitHub Developer Settings and provide the generated Client ID and Client Secret.
 
-Create a `.env` file in the project root and add your Firebase configuration:
+Create a Web App
+Open Project Settings (⚙️ icon).
 
-```env
+Under General, scroll down to Your Apps.
+
+Click Add App → Web App.
+
+Copy the Firebase configuration values.
+
+🔑 Step 3: Environment Variables
+Create a .env file in the project root and add your Firebase configuration:
+
+Code snippet
 VITE_FIREBASE_API_KEY=your_api_key_here
 VITE_FIREBASE_AUTH_DOMAIN=your_project_id.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=your_project_id
@@ -79,118 +76,76 @@ VITE_FIREBASE_STORAGE_BUCKET=your_project_id.firebasestorage.app
 VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
 VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
-```
+⚠️ Important: Never commit your .env file. It is already included in .gitignore.
 
-> ⚠️ **Important:** Never commit your `.env` file. It is already included in `.gitignore`.
-
----
-
-## 📦 Step 4: Firebase CLI and Database Setup
-
+📦 Step 4: Firebase CLI and Database Setup
 Deploy the required Firestore Security Rules and Indexes so leaderboard queries function correctly.
 
-### Install Firebase CLI
-
-```bash
+Install Firebase CLI
+Bash
 npm install -g firebase-tools
-```
-
-### Authenticate with Firebase
-
-```bash
+Authenticate with Firebase
+Bash
 firebase login
-```
-
-### Link Your Firebase Project
-
-```bash
+Link Your Firebase Project
+Bash
 firebase use --add
-```
+Select your rankerhub-dev project when prompted.
 
-Select your `rankerhub-dev` project when prompted.
-
-### Deploy Firestore Rules and Indexes
-
-```bash
+Deploy Firestore Rules and Indexes
+Bash
 firebase deploy --only firestore:rules,firestore:indexes
-```
+Note: Firestore index creation may take several minutes to complete.
 
-> **Note:** Firestore index creation may take several minutes to complete.
-
----
-
-## 🗄️ Step 5: Local Database Emulator Setup
-
+🗄️ Step 5: Local Database Emulator Setup
 To avoid working directly against a live database, use the Firestore Emulator.
 
-### Start the Firestore Emulator
-
-```bash
+Start the Firestore Emulator
+Bash
 firebase emulators:start --only firestore
-```
-
-### Seed Development Data
-
+Seed Development Data
 Open a new terminal window and run:
 
-```bash
+Bash
 npm run seed
-```
-
 This populates the emulator with mock user profiles and sample leaderboard data for local development.
 
----
-
-## 💻 Step 6: Run the Development Server
-
+💻 Step 6: Run the Development Server
 Start the Vite development server:
 
-```bash
+Bash
 npm run dev
-```
-
 Open your browser and navigate to:
 
-```text
+Plaintext
 http://localhost:5173
-```
-
 You can now log in using GitHub authentication. Your first developer profile will be automatically created in the local Firestore emulator.
 
----
-
-## 🤝 Contribution Workflow
-
-### Create a Feature Branch
-
-```bash
+🤝 Contribution Workflow
+Create a Feature Branch
+Bash
 git checkout -b feature/your-feature-name
-```
+Develop and Test
+Make your changes.
 
-### Develop and Test
+Test everything locally.
 
-- Make your changes.
-- Test everything locally.
-- Verify functionality using the Firestore emulator.
+Verify functionality using the Firestore emulator.
 
-### Commit Changes
-
+Commit Changes
 Use the project's commit conventions:
 
-```text
+Plaintext
 feat: add leaderboard filtering
 fix: resolve authentication redirect issue
 docs: update setup instructions
-```
+Submit Your Contribution
+Push your branch to your fork.
 
-### Submit Your Contribution
+Open a Pull Request against the main branch of the official RankerHub repository.
 
-1. Push your branch to your fork.
-2. Open a Pull Request against the main branch of the official RankerHub repository.
-3. Wait for review and feedback.
+Wait for review and feedback.
 
----
-
-## 🚀 Happy Coding!
-
+🚀 Happy Coding
 Thanks for contributing to RankerHub. We appreciate your help in making the project better for everyone.
+````

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2,13 +2,15 @@
 
 Welcome to the RankerHub developer documentation! This guide will help you set up the project locally on your machine, connect it to your own Firebase development environment, and start contributing.
 
+---
+
 ## 📋 Prerequisites
 
 Before you begin, ensure you have the following installed:
 
 - **Node.js** (v18.0.0 or higher recommended)
 - **Git**
-- **A Google/Firebase Account** (for local database testing)
+- **Google/Firebase Account** (for local database testing)
 - **GitHub Account** (to test OAuth login)
 
 ---
@@ -16,38 +18,58 @@ Before you begin, ensure you have the following installed:
 ## 🚀 Step 1: Clone and Install Dependencies
 
 1. Fork the repository on GitHub.
-2. Clone your forked repository to your local machine:
+2. Clone your forked repository:
 
 ```bash
 git clone https://github.com/<your-username>/RankerHub.git
 cd RankerHub
 ```
 
-Install the required NPM packages:
+3. Install the required dependencies:
 
 ```bash
 npm install
 ```
 
+---
+
 ## 🔥 Step 2: Firebase Project Provisioning
 
-To prevent testing on the production database, you should create your own Firebase project for local development.
+To prevent testing against the production database, create your own Firebase project for local development.
 
-Go to the Firebase Console and click "Add Project".
+### Create a Firebase Project
 
-Name it something like `rankerhub-dev` and complete the setup.
+1. Open the Firebase Console.
+2. Click **Add Project**.
+3. Name it something like `rankerhub-dev`.
+4. Complete the setup process.
 
-In the Firebase dashboard, go to **Build > Firestore Database** and click **Create Database** (Start in Test Mode).
+### Configure Firestore
 
-Go to **Build > Authentication**, click **Get Started**, and enable the GitHub sign-in provider.
+1. Navigate to **Build → Firestore Database**.
+2. Click **Create Database**.
+3. Select **Start in Test Mode**.
 
-> (Note: You will need to create a new OAuth App in your GitHub Developer Settings and paste the Client ID and Secret here).
+### Configure Authentication
 
-Go to **Project Settings (Gear icon) > General**, scroll down, and add a Web App. Copy the configuration keys.
+1. Navigate to **Build → Authentication**.
+2. Click **Get Started**.
+3. Enable the **GitHub** sign-in provider.
+
+> **Note:** You will need to create a GitHub OAuth App in GitHub Developer Settings and provide the generated Client ID and Client Secret.
+
+### Create a Web App
+
+1. Open **Project Settings** (⚙️ icon).
+2. Under **General**, scroll down to **Your Apps**.
+3. Click **Add App → Web App**.
+4. Copy the Firebase configuration values.
+
+---
 
 ## 🔑 Step 3: Environment Variables
 
-Create a new file named `.env` in the root of your project directory. Add your newly created Firebase config keys here:
+Create a `.env` file in the project root and add your Firebase configuration:
 
 ```env
 VITE_FIREBASE_API_KEY=your_api_key_here
@@ -59,68 +81,116 @@ VITE_FIREBASE_APP_ID=your_app_id
 VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
 ```
 
-> ⚠️ Important: Never commit your `.env` file. It is already included in our `.gitignore`.
+> ⚠️ **Important:** Never commit your `.env` file. It is already included in `.gitignore`.
+
+---
 
 ## 📦 Step 4: Firebase CLI and Database Setup
 
-We need to deploy the required Firestore Security Rules and Indexes so the Leaderboard queries work locally.
+Deploy the required Firestore Security Rules and Indexes so leaderboard queries function correctly.
 
-Install the Firebase CLI globally:
+### Install Firebase CLI
 
 ```bash
 npm install -g firebase-tools
 ```
 
-Log in to your Firebase account via terminal:
+### Authenticate with Firebase
 
 ```bash
 firebase login
 ```
 
-Initialize the project (select your `rankerhub-dev` project):
+### Link Your Firebase Project
 
 ```bash
 firebase use --add
 ```
 
-Deploy the security rules and composite indexes:
+Select your `rankerhub-dev` project when prompted.
+
+### Deploy Firestore Rules and Indexes
 
 ```bash
 firebase deploy --only firestore:rules,firestore:indexes
 ```
 
-> (Note: Building indexes might take a few minutes in the Firebase Console).
+> **Note:** Firestore index creation may take several minutes to complete.
 
-## 💻 Step 5: Run the Local Development Server
+---
 
-You are all set! Start the Vite development server:
+## 🗄️ Step 5: Local Database Emulator Setup
+
+To avoid working directly against a live database, use the Firestore Emulator.
+
+### Start the Firestore Emulator
+
+```bash
+firebase emulators:start --only firestore
+```
+
+### Seed Development Data
+
+Open a new terminal window and run:
+
+```bash
+npm run seed
+```
+
+This populates the emulator with mock user profiles and sample leaderboard data for local development.
+
+---
+
+## 💻 Step 6: Run the Development Server
+
+Start the Vite development server:
 
 ```bash
 npm run dev
 ```
 
-Open your browser and navigate to `http://localhost:5173`.
+Open your browser and navigate to:
 
-You can now log in via GitHub, which will automatically seed your first developer profile into your local Firestore database.
+```text
+http://localhost:5173
+```
+
+You can now log in using GitHub authentication. Your first developer profile will be automatically created in the local Firestore emulator.
+
+---
 
 ## 🤝 Contribution Workflow
 
-Create a new branch for your feature or bugfix:
+### Create a Feature Branch
 
 ```bash
 git checkout -b feature/your-feature-name
 ```
 
-Make your changes and test them locally.
+### Develop and Test
 
-Commit using our standard convention:
+- Make your changes.
+- Test everything locally.
+- Verify functionality using the Firestore emulator.
+
+### Commit Changes
+
+Use the project's commit conventions:
 
 ```text
-feat: ...
-fix: ...
-docs: ...
+feat: add leaderboard filtering
+fix: resolve authentication redirect issue
+docs: update setup instructions
 ```
 
-Push to your fork and submit a Pull Request to the main branch of the official RankerHub repository.
+### Submit Your Contribution
 
-Happy Coding 🚀
+1. Push your branch to your fork.
+2. Open a Pull Request against the main branch of the official RankerHub repository.
+3. Wait for review and feedback.
+
+---
+
+## 🚀 Happy Coding!
+
+Thanks for contributing to RankerHub. We appreciate your help in making the project better for everyone.


### PR DESCRIPTION
## Description

This PR resolves #311 by updating the `DEVELOPER_GUIDE.md` to include missing instructions for configuring and running the local Firestore database emulators.

## Key Changes

### Added Local Database Setup

- Inserted a new **Step 5** documenting how to start the local Firestore emulator:
  ```bash
  firebase emulators:start --only firestore
  ```
- Clarified that contributors should use the emulator during development rather than connecting directly to a live database.

### Added Mock Data Seeding

- Added instructions for running the seed script:
  ```bash
  npm run seed
  ```
- Ensures the local database is populated with sample data for the GitRank and Referral leaderboards.
- Prevents new contributors from encountering empty states when running the application locally.

### Improved Onboarding Flow

- Moved the Vite development server startup instructions to **Step 6**.
- Reordered the setup process so database configuration and seeding occur before launching the client application.
- Creates a more logical and reliable onboarding experience for new developers.

## Fixes

Closes #311