### PR TITLE
style: balance dark mode glass highlights and caustics (#313)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -514,8 +514,8 @@
   --glass-bg: rgba(15, 23, 42, 0.35);
   --glass-border: rgba(255, 255, 255, 0.12);
   --glass-shadow: rgba(0, 0, 0, 0.5);
-  --glass-highlight: rgba(255, 255, 255, 0.22);
-  --glass-caustic: rgba(255, 255, 255, 0.04);
+  --glass-highlight: rgba(255, 255, 255, 0.08); 
+  --glass-caustic: rgba(255, 255, 255, 0.08);   
   --reflection-start: rgba(255, 255, 255, 0.12);
   --reflection-end: rgba(255, 255, 255, 0.0);
   --glare-color: rgba(255, 255, 255, 0.12);


### PR DESCRIPTION
## Description

This PR resolves #313 by fine-tuning the dark mode glassmorphic liquid navbar variables to reduce visual over-exposure and improve rendering quality on high-contrast displays.

## Key Changes

### Smoother Top Edge

- Reduced the `--glass-highlight` opacity from **0.22** to **0.08**.
- Softens the bright white reflection along the upper boundary of the navigation bar.
- Reduces harsh contrast and minimizes the appearance of jagged edges in dark mode.

### Improved Volumetric Depth

- Increased the `--glass-caustic` opacity from **0.04** to **0.08**.
- Enhances the subtle light refraction effect beneath the navbar.
- Creates a more natural glow and reinforces the liquid glass aesthetic.

### Visual Refinements

- Balances highlight and refraction intensity for a smoother overall appearance.
- Improves readability and visual comfort on high-contrast and OLED displays.
- Preserves the existing glassmorphic design while making the effect feel more polished and realistic.

## Fixes

Closes #313