### PR TITLE
feat: sync active leaderboard tab with URL parameters for persistence

### DIFF
--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -20,8 +20,8 @@ export const GitRank = () => {
   const searchTerm = searchParams.get("search") || "";
   const selectedLanguage = searchParams.get("lang") || "All";
 
-  // Active Tab for Referral Leaderboard (Issue #214)
-  const [activeTab, setActiveTab] = useState("gitrank"); // "gitrank" | "referrals"
+  // Active Tab for Referral Leaderboard (Issue #310) - Now synced with URL
+  const activeTab = searchParams.get("tab") || "gitrank";
 
   const handleSearchChange = (e) => {
     const val = e.target.value;
@@ -36,6 +36,12 @@ export const GitRank = () => {
     const newParams = new URLSearchParams(searchParams);
     if (lang !== "All") newParams.set("lang", lang);
     else newParams.delete("lang");
+    setSearchParams(newParams);
+  };
+
+  const handleTabChange = (tabName) => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set("tab", tabName);
     setSearchParams(newParams);
   };
   
@@ -905,7 +911,7 @@ export const GitRank = () => {
         {/* NEW TAB SYSTEM FOR REFERRAL LEADERBOARD */}
         <div className="flex items-center gap-2 mb-6 p-1 bg-slate-100 dark:bg-slate-800/50 rounded-xl w-fit">
           <button
-            onClick={() => setActiveTab("gitrank")}
+            onClick={() => handleTabChange("gitrank")}
             className={`px-4 py-2 text-xs font-bold rounded-lg transition-all flex items-center gap-2 ${
               activeTab === "gitrank"
                 ? "bg-white dark:bg-slate-700 text-violet-600 dark:text-violet-400 shadow-sm"
@@ -916,7 +922,7 @@ export const GitRank = () => {
             GitRank Leaderboard
           </button>
           <button
-            onClick={() => setActiveTab("referrals")}
+            onClick={() => handleTabChange("referrals")}
             className={`px-4 py-2 text-xs font-bold rounded-lg transition-all flex items-center gap-2 ${
               activeTab === "referrals"
                 ? "bg-white dark:bg-slate-700 text-emerald-600 dark:text-emerald-400 shadow-sm"


### PR DESCRIPTION
## Summary
Persist leaderboard active tab (GitRank vs Referrals) in URL parameters so users can reload the page and stay on their selected tab, and share shareable links to specific leaderboard views.

## Problem Statement
- Active tab state stored in local component useState
- Page reload resets to default "GitRank Leaderboard" tab
- Users cannot share direct links to Referrals leaderboard view
- No persistence mechanism exists for tab selection

## Solution
- Read activeTab from URL: `searchParams.get("tab") || "gitrank"`
- Replace setState calls with searchParams updates
- handleTabChange function manages URL and tab sync
- Leverages existing useSearchParams pattern used for search/filter

## Technical Implementation
- Changed: `const [activeTab, setActiveTab] = useState("gitrank")`
- To: `const activeTab = searchParams.get("tab") || "gitrank"`
- Added handleTabChange function to update URL on tab switch
- Updated button onClick handlers: `onClick={() => handleTabChange("gitrank")}`

## Benefits
- Tab selection persists across page reloads
- Users can share URLs like `?tab=referrals` for Referrals leaderboard
- Consistent with existing search/filter URL sync pattern
- Single source of truth (URL) for tab state

## Test Plan
- [ ] Click referrals tab, reload page, verify tab persists
- [ ] Share referrals tab URL with another user
- [ ] Verify gitrank tab is default when no tab param
- [ ] Test back/forward browser buttons with tab changes

Closes #310

Signed-off-by: Anshul Jain <anshul23102@iiitd.ac.in>