### PR TITLE
fix: persist habits and pomodoro state in localstorage (#304)

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -137,7 +137,7 @@ export const AuthProvider = ({ children }) => {
               setLoading(false);
             }, null);
           }
-        }, (error) => {
+        }, (_error) => {
           setLoading(false);
         });
 

--- a/src/pages/CodingOwl.jsx
+++ b/src/pages/CodingOwl.jsx
@@ -13,28 +13,41 @@ export const CodingOwl = () => {
 
   // --- Habit Checklist Persistence ---
   const [habits, setHabits] = useState(() => {
-    const savedHabits = localStorage.getItem("codingOwlHabits");
-    return savedHabits ? JSON.parse(savedHabits) : habitCards;
+    if (typeof window !== "undefined") {
+      const savedHabits = localStorage.getItem("codingOwlHabits");
+      return savedHabits ? JSON.parse(savedHabits) : habitCards;
+    }
+    return habitCards;
   });
 
   useEffect(() => {
     localStorage.setItem("codingOwlHabits", JSON.stringify(habits));
   }, [habits]);
 
-  // --- Pomodoro Persistence Logic (Refactored for strict linting) ---
-  const getInitialTimerState = () => {
-    const savedEndTime = localStorage.getItem("pomodoroEndTime");
-    if (savedEndTime) {
-      const remainingTime = Math.floor((parseInt(savedEndTime, 10) - Date.now()) / 1000);
-      if (remainingTime > 0) return { timeLeft: remainingTime, active: true };
-      localStorage.removeItem("pomodoroEndTime");
+  // --- Pomodoro Persistence Logic (Strict React Purity Fix) ---
+  const [timeLeft, setTimeLeft] = useState(() => {
+    if (typeof window !== "undefined") {
+      const savedEndTime = localStorage.getItem("pomodoroEndTime");
+      if (savedEndTime) {
+        const remainingTime = Math.floor((parseInt(savedEndTime, 10) - Date.now()) / 1000);
+        if (remainingTime > 0) return remainingTime;
+      }
     }
-    return { timeLeft: 1500, active: false }; // Default 25 mins
-  };
+    return 1500; // Default 25 mins
+  });
 
-  const initialTimer = getInitialTimerState();
-  const [timeLeft, setTimeLeft] = useState(initialTimer.timeLeft);
-  const [timerActive, setTimerActive] = useState(initialTimer.active);
+  const [timerActive, setTimerActive] = useState(() => {
+    if (typeof window !== "undefined") {
+      const savedEndTime = localStorage.getItem("pomodoroEndTime");
+      if (savedEndTime) {
+        const remainingTime = Math.floor((parseInt(savedEndTime, 10) - Date.now()) / 1000);
+        if (remainingTime > 0) return true;
+        localStorage.removeItem("pomodoroEndTime");
+      }
+    }
+    return false;
+  });
+
   const timerRef = useRef(null);
 
   useEffect(() => {
@@ -56,7 +69,7 @@ export const CodingOwl = () => {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
     };
-  }, [timerActive]); 
+  }, [timerActive]);
 
   const toggleTimer = () => {
     if (timerActive) {

--- a/src/pages/CodingOwl.jsx
+++ b/src/pages/CodingOwl.jsx
@@ -21,33 +21,24 @@ export const CodingOwl = () => {
     localStorage.setItem("codingOwlHabits", JSON.stringify(habits));
   }, [habits]);
 
-  // --- Pomodoro Persistence Logic ---
-  const [timeLeft, setTimeLeft] = useState(1500); // Default 25 mins
-  const [timerActive, setTimerActive] = useState(false);
-  const timerRef = useRef(null);
-
-  useEffect(() => {
+  // --- Pomodoro Persistence Logic (Refactored for strict linting) ---
+  const getInitialTimerState = () => {
     const savedEndTime = localStorage.getItem("pomodoroEndTime");
     if (savedEndTime) {
       const remainingTime = Math.floor((parseInt(savedEndTime, 10) - Date.now()) / 1000);
-      if (remainingTime > 0) {
-        setTimeLeft(remainingTime);
-        setTimerActive(true);
-      } else {
-        localStorage.removeItem("pomodoroEndTime");
-        setTimeLeft(0);
-      }
+      if (remainingTime > 0) return { timeLeft: remainingTime, active: true };
+      localStorage.removeItem("pomodoroEndTime");
     }
-  }, []);
+    return { timeLeft: 1500, active: false }; // Default 25 mins
+  };
+
+  const initialTimer = getInitialTimerState();
+  const [timeLeft, setTimeLeft] = useState(initialTimer.timeLeft);
+  const [timerActive, setTimerActive] = useState(initialTimer.active);
+  const timerRef = useRef(null);
 
   useEffect(() => {
     if (timerActive) {
-      // If timer just started and hasn't been saved yet
-      if (!localStorage.getItem("pomodoroEndTime")) {
-        const endTime = Date.now() + timeLeft * 1000;
-        localStorage.setItem("pomodoroEndTime", endTime.toString());
-      }
-
       timerRef.current = setInterval(() => {
         setTimeLeft((prev) => {
           if (prev <= 1) {
@@ -65,7 +56,7 @@ export const CodingOwl = () => {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
     };
-  }, [timerActive]); // Intentionally omitting timeLeft from deps to avoid re-triggering interval
+  }, [timerActive]); 
 
   const toggleTimer = () => {
     if (timerActive) {
@@ -75,6 +66,8 @@ export const CodingOwl = () => {
     } else {
       // Starting/Resuming the timer
       setTimerActive(true);
+      const endTime = Date.now() + timeLeft * 1000;
+      localStorage.setItem("pomodoroEndTime", endTime.toString());
     }
   };
 
@@ -220,7 +213,7 @@ export const CodingOwl = () => {
                 </div>
 
                 <button
-                  onClick={() => toggleHabit.complete(habit.id)}
+                  onClick={() => toggleHabitComplete(habit.id)}
                   className={`w-full py-1.5 rounded-lg text-xs font-bold transition-all flex items-center justify-center gap-1 cursor-pointer ${
                     habit.progress === 100
                       ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20"

--- a/src/pages/CodingOwl.jsx
+++ b/src/pages/CodingOwl.jsx
@@ -9,19 +9,51 @@ export const CodingOwl = () => {
   const { userData } = useAuth();
   const userName = userData?.name || "Developer";
   const loginStreak = userData?.streak || 0;
-  const githubStreak = userData?.githubStreak || 0; // New GitHub Live Streak
-  const [habits, setHabits] = useState(habitCards);
-  const [timeLeft, setTimeLeft] = useState(1500); // 25:00 in seconds
+  const githubStreak = userData?.githubStreak || 0;
+
+  // --- Habit Checklist Persistence ---
+  const [habits, setHabits] = useState(() => {
+    const savedHabits = localStorage.getItem("codingOwlHabits");
+    return savedHabits ? JSON.parse(savedHabits) : habitCards;
+  });
+
+  useEffect(() => {
+    localStorage.setItem("codingOwlHabits", JSON.stringify(habits));
+  }, [habits]);
+
+  // --- Pomodoro Persistence Logic ---
+  const [timeLeft, setTimeLeft] = useState(1500); // Default 25 mins
   const [timerActive, setTimerActive] = useState(false);
   const timerRef = useRef(null);
 
   useEffect(() => {
+    const savedEndTime = localStorage.getItem("pomodoroEndTime");
+    if (savedEndTime) {
+      const remainingTime = Math.floor((parseInt(savedEndTime, 10) - Date.now()) / 1000);
+      if (remainingTime > 0) {
+        setTimeLeft(remainingTime);
+        setTimerActive(true);
+      } else {
+        localStorage.removeItem("pomodoroEndTime");
+        setTimeLeft(0);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
     if (timerActive) {
+      // If timer just started and hasn't been saved yet
+      if (!localStorage.getItem("pomodoroEndTime")) {
+        const endTime = Date.now() + timeLeft * 1000;
+        localStorage.setItem("pomodoroEndTime", endTime.toString());
+      }
+
       timerRef.current = setInterval(() => {
         setTimeLeft((prev) => {
           if (prev <= 1) {
             clearInterval(timerRef.current);
             setTimerActive(false);
+            localStorage.removeItem("pomodoroEndTime");
             return 0;
           }
           return prev - 1;
@@ -33,15 +65,23 @@ export const CodingOwl = () => {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
     };
-  }, [timerActive]);
+  }, [timerActive]); // Intentionally omitting timeLeft from deps to avoid re-triggering interval
 
   const toggleTimer = () => {
-    setTimerActive(!timerActive);
+    if (timerActive) {
+      // Pausing the timer
+      setTimerActive(false);
+      localStorage.removeItem("pomodoroEndTime");
+    } else {
+      // Starting/Resuming the timer
+      setTimerActive(true);
+    }
   };
 
   const resetTimer = () => {
     setTimerActive(false);
     setTimeLeft(1500);
+    localStorage.removeItem("pomodoroEndTime");
   };
 
   const formatTime = (seconds) => {
@@ -51,14 +91,16 @@ export const CodingOwl = () => {
   };
 
   const toggleHabitComplete = (id) => {
-    setHabits(prev => prev.map(habit => {
-      if (habit.id === id) {
-        const newProgress = habit.progress === 100 ? 0 : 100;
-        const newStreak = newProgress === 100 ? habit.streak + 1 : Math.max(0, habit.streak - 1);
-        return { ...habit, progress: newProgress, streak: newStreak };
-      }
-      return habit;
-    }));
+    setHabits((prev) =>
+      prev.map((habit) => {
+        if (habit.id === id) {
+          const newProgress = habit.progress === 100 ? 0 : 100;
+          const newStreak = newProgress === 100 ? habit.streak + 1 : Math.max(0, habit.streak - 1);
+          return { ...habit, progress: newProgress, streak: newStreak };
+        }
+        return habit;
+      })
+    );
   };
 
   return (
@@ -73,10 +115,8 @@ export const CodingOwl = () => {
 
       {/* Mascot & Streak Highlight */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        
         {/* Mascot bubble */}
         <Card className="lg:col-span-2 p-8 flex flex-col sm:flex-row items-center gap-6 bg-gradient-to-br from-orange-500/10 via-slate-50/0 to-slate-50/0 dark:from-orange-500/5 dark:via-slate-900/0 dark:to-slate-900/0 border-orange-500/15">
-          {/* Mascot representation */}
           <div className="w-28 h-28 rounded-full bg-gradient-to-tr from-orange-400 to-red-500 flex items-center justify-center text-4xl shadow-lg border border-orange-400/25 flex-shrink-0 animate-bounce">
             🦉
           </div>
@@ -85,11 +125,11 @@ export const CodingOwl = () => {
             <h3 className="text-xl font-extrabold text-slate-950 dark:text-white my-0">
               Mascot: Oliver the Owl
             </h3>
-            
+
             <div className="bg-white/80 dark:bg-slate-950/60 p-4 rounded-xl border border-slate-200/40 dark:border-slate-800/45 text-sm text-slate-600 dark:text-slate-300 leading-relaxed font-semibold italic relative">
               "Whoo-whoo! You've pushed code to GitHub for {githubStreak} consecutive days, {userName}. Oliver is proud! Maintain your live GitHub streak today to earn your +10 XP daily bonus."
             </div>
-            
+
             <div className="flex justify-center sm:justify-start items-center gap-4 text-xs font-bold text-slate-400">
               <span>Mood: <span className="text-orange-500">Ecstatic! 🔥</span></span>
               <span>•</span>
@@ -124,8 +164,8 @@ export const CodingOwl = () => {
             <button
               onClick={toggleTimer}
               className={`flex-1 py-2.5 rounded-xl font-bold border text-sm transition-all duration-300 flex items-center justify-center gap-2 cursor-pointer ${
-                timerActive 
-                  ? "bg-amber-500 hover:bg-amber-600 text-white border-amber-500" 
+                timerActive
+                  ? "bg-amber-500 hover:bg-amber-600 text-white border-amber-500"
                   : "bg-gradient-to-r from-orange-500 to-red-500 hover:opacity-90 text-white border-orange-500"
               }`}
             >
@@ -139,7 +179,6 @@ export const CodingOwl = () => {
             </button>
           </div>
         </Card>
-
       </div>
 
       {/* Habits Checklist Grid */}
@@ -147,7 +186,7 @@ export const CodingOwl = () => {
         <h3 className="font-extrabold text-lg text-slate-900 dark:text-white my-0">
           Your Habit Dashboard
         </h3>
-        
+
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {habits.map((habit) => (
             <Card key={habit.id} className="p-5 flex flex-col justify-between border-slate-200/50 dark:border-slate-800/50 hover:border-orange-500/25 transition-all">
@@ -156,7 +195,7 @@ export const CodingOwl = () => {
                   <span className="px-2 py-0.5 rounded-full text-[9px] font-bold bg-orange-500/10 text-orange-500 dark:text-orange-400 border border-orange-500/20">
                     {habit.frequency}
                   </span>
-                  
+
                   <span className="text-xs font-bold text-orange-500 dark:text-orange-400 flex items-center gap-0.5">
                     🔥 {habit.streak}d
                   </span>
@@ -165,7 +204,7 @@ export const CodingOwl = () => {
                 <h4 className="font-extrabold text-slate-900 dark:text-white leading-tight my-0">
                   {habit.title}
                 </h4>
-                
+
                 <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed font-medium">
                   {habit.description}
                 </p>
@@ -179,9 +218,9 @@ export const CodingOwl = () => {
                     {habit.progress === 100 ? "Completed" : "In Progress"}
                   </span>
                 </div>
-                
+
                 <button
-                  onClick={() => toggleHabitComplete(habit.id)}
+                  onClick={() => toggleHabit.complete(habit.id)}
                   className={`w-full py-1.5 rounded-lg text-xs font-bold transition-all flex items-center justify-center gap-1 cursor-pointer ${
                     habit.progress === 100
                       ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20"
@@ -224,7 +263,7 @@ export const CodingOwl = () => {
               <span className="text-xs font-bold text-slate-400 block text-center">
                 Week {week.week}
               </span>
-              
+
               <div className="flex justify-between items-center gap-1.5 py-3 px-4 rounded-xl bg-slate-50 dark:bg-slate-950/30 border border-slate-200/40 dark:border-slate-800/40">
                 {week.days.map((day, dayIdx) => (
                   <div
@@ -233,8 +272,8 @@ export const CodingOwl = () => {
                       day === 2
                         ? "bg-gradient-to-r from-orange-500 to-red-500 shadow-md shadow-orange-500/20"
                         : day === 1
-                          ? "bg-orange-500/40 dark:bg-orange-500/20"
-                          : "bg-slate-200 dark:bg-slate-800/50"
+                        ? "bg-orange-500/40 dark:bg-orange-500/20"
+                        : "bg-slate-200 dark:bg-slate-800/50"
                     }`}
                     title={`Day status: ${day}`}
                   />
@@ -259,7 +298,6 @@ export const CodingOwl = () => {
           </div>
         </div>
       </Card>
-
     </div>
   );
 };


### PR DESCRIPTION
## Description
This PR resolves #304 by ensuring that user progress in the CodingOwl component is persisted across page refreshes and navigation. Previously, all state was held in volatile useState hooks, causing data loss whenever the component unmounted.

## Key Changes
Habit Persistence: Implemented lazy initialization and useEffect syncs for the habit checklist, ensuring completion status is saved and hydrated via localStorage.

Pomodoro Resilience: Transitioned the timer logic from a simple timeLeft state to an endTime timestamp-based calculation. This allows the timer to seamlessly resume countdowns even if the user refreshes the page or navigates away.

State Recovery: Added cleanup logic to clear expired session storage, ensuring the timer resets correctly after completion.

Fixes #304