### PR TITLE
fix: Implement chunked Firestore queries for connection hydration (#305)

### DIFF
--- a/src/pages/Friends.jsx
+++ b/src/pages/Friends.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Activity, HeartHandshake, UserCheck, UserPlus, UsersRound } from "lucide-react";
 import SectionHeader from "../components/ui/SectionHeader";
@@ -35,7 +35,16 @@ export const Friends = () => {
   const [loading, setLoading] = useState(true);
   const [followingIds, setFollowingIds] = useState([]);
   const [followerIds, setFollowerIds] = useState([]);
+  
+  // NEW: State to hold the asynchronously fetched connections
+  const [connections, setConnections] = useState({
+    friends: [],
+    followers: [],
+    following: [],
+    suggested: []
+  });
 
+  // 1. Initial Load & Setup Listeners
   useEffect(() => {
     let unsubFollowing = () => {};
     let unsubFollowers = () => {};
@@ -55,7 +64,6 @@ export const Friends = () => {
     if (currentUser?.uid) {
       loadDevelopers();
       
-      // Setup Real-time Firebase Listeners
       unsubFollowing = subscribeToFollowing(currentUser.uid, (ids) => {
         setFollowingIds(ids);
       });
@@ -71,12 +79,27 @@ export const Friends = () => {
     };
   }, [currentUser]);
 
-  const connections = useMemo(
-    () => hydrateConnections(developers, followingIds, followerIds),
-    [developers, followingIds, followerIds]
-  );
+  // 2. NEW: Async Hydration Effect
+  // This replaces useMemo because hydrateConnections now fetches missing users from Firestore
+  useEffect(() => {
+    let isMounted = true;
 
-  const activeDevelopers = connections[activeTab];
+    const runHydration = async () => {
+      const data = await hydrateConnections(developers, followingIds, followerIds);
+      if (isMounted) {
+        setConnections(data);
+      }
+    };
+
+    runHydration();
+
+    return () => {
+      isMounted = false; // Prevents state updates if component unmounts during fetch
+    };
+  }, [developers, followingIds, followerIds]);
+
+  const activeDevelopers = connections[activeTab] || [];
+  
   const tabCopy = {
     friends: "Developers who follow you back and collaborate with you across RankerHub.",
     followers: "Developers tracking your public progress, badges, and challenge activity.",

--- a/src/services/friendsService.js
+++ b/src/services/friendsService.js
@@ -1,4 +1,4 @@
-import { collection, getDocs, doc, setDoc, deleteDoc, onSnapshot, query, where, limit } from "firebase/firestore";
+import { collection, getDocs, doc, setDoc, deleteDoc, onSnapshot, query, where, limit, documentId } from "firebase/firestore";
 import { db } from "../lib/firebase";
 
 // Asynchronously fetch real users from Firebase (capped at 50 to avoid
@@ -24,6 +24,45 @@ export const fetchDevelopers = async () => {
     });
   } catch (error) {
     console.error("Error fetching developers: ", error);
+    return [];
+  }
+};
+
+// --- NEW FIX: Chunked Firestore Query to bypass 30-item limit ---
+export const fetchUsersByIds = async (userIds) => {
+  if (!userIds || userIds.length === 0) return [];
+
+  // Firestore "in" queries max out at 30 items. We must chunk the array.
+  const chunks = [];
+  for (let i = 0; i < userIds.length; i += 30) {
+    chunks.push(userIds.slice(i, i + 30));
+  }
+
+  try {
+    const users = [];
+    for (const chunk of chunks) {
+      const q = query(collection(db, "users"), where(documentId(), "in", chunk));
+      const snapshot = await getDocs(q);
+      
+      snapshot.docs.forEach(doc => {
+        const data = doc.data();
+        users.push({
+          id: doc.id,
+          name: data.displayName || data.name || data.githubUsername || "Unknown Developer",
+          username: data.githubUsername || doc.id,
+          avatar: data.photoURL || data.avatarUrl || `https://ui-avatars.com/api/?name=${data.displayName || 'Dev'}&background=random`,
+          role: data.role || "Developer",
+          bio: data.bio || "Building awesome projects on RankerHub.",
+          tags: data.skills || ["Developer"],
+          mutualFriends: 0,
+          online: false,
+          activity: "Recently joined RankerHub"
+        });
+      });
+    }
+    return users;
+  } catch (error) {
+    console.error("Error fetching chunked users:", error);
     return [];
   }
 };
@@ -56,10 +95,8 @@ export const toggleFollowStatus = async (currentUserId, developerId, isFollowing
 
   try {
     if (isFollowing) {
-      // Unfollow
       await deleteDoc(followRef);
     } else {
-      // Follow
       await setDoc(followRef, {
         followerId: currentUserId,
         followedId: developerId,
@@ -71,15 +108,29 @@ export const toggleFollowStatus = async (currentUserId, developerId, isFollowing
   }
 };
 
-export const hydrateConnections = (developers, followingIds, followerIds) => {
-  if (!developers) return { friends: [], followers: [], following: [], suggested: [] };
+// --- UPDATED FIX: Now async and fetches missing profiles dynamically ---
+export const hydrateConnections = async (suggestedDevelopers, followingIds, followerIds) => {
+  // 1. Get a unique list of all IDs we actually need to render
+  const uniqueConnectionIds = [...new Set([...followingIds, ...followerIds])];
 
-  const following = developers.filter((developer) => followingIds.includes(developer.id));
-  const followers = developers.filter((developer) => followerIds.includes(developer.id));
-  const friends = developers.filter(
-    (developer) => followingIds.includes(developer.id) && followerIds.includes(developer.id)
-  );
-  const suggested = developers.filter((developer) => !followingIds.includes(developer.id));
+  // 2. Fetch specific user profiles dynamically (ignoring the 50 limit constraint)
+  const fetchedConnections = await fetchUsersByIds(uniqueConnectionIds);
+
+  // 3. Map them for quick lookup
+  const connectionMap = {};
+  fetchedConnections.forEach(dev => {
+    connectionMap[dev.id] = dev;
+  });
+
+  // 4. Hydrate exact arrays (filter(Boolean) removes deleted accounts automatically)
+  const following = followingIds.map(id => connectionMap[id]).filter(Boolean);
+  const followers = followerIds.map(id => connectionMap[id]).filter(Boolean);
+  
+  const friendIds = followingIds.filter(id => followerIds.includes(id));
+  const friends = friendIds.map(id => connectionMap[id]).filter(Boolean);
+
+  // 5. Suggested pool remains the standard fetchDevelopers result, minus those we follow
+  const suggested = (suggestedDevelopers || []).filter(dev => !followingIds.includes(dev.id));
 
   return {
     friends,


### PR DESCRIPTION
## Description
This PR resolves #305 by ensuring users who fall outside of the initial 50-user fetchDevelopers query are still accurately hydrated and displayed in the "Following" and "Followers" tabs.

## Key Changes
Chunked Firestore Queries: Added a new helper function fetchUsersByIds that segments arrays of IDs into batches of 30, bypassing Firestore's strict in clause query limits.

Dynamic Hydration: Refactored hydrateConnections into an asynchronous function. Instead of statically filtering the generic user pool, it now precisely fetches the exact documents associated with the active user's connection IDs.

Orphaned Account Cleanup: Added .filter(Boolean) mapping chains to ensure the UI doesn't crash if an ID exists in the follows collection but the corresponding user document has been deleted.

Fixes #305