### PR TITLE
Fix/issue 316 onboarding college validation

### DIFF
--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -109,6 +109,29 @@ export const Onboarding = () => {
     }
   };
 
+  const handleCollegeBlur = () => {
+    if (!collegeSearch.trim()) {
+      return;
+    }
+    const exactMatch = collegesList.find(
+      (c) => c.toLowerCase() === collegeSearch.trim().toLowerCase()
+    );
+
+    if (exactMatch) {
+      setSelectedCollege(exactMatch);
+      setCollegeSearch(exactMatch);
+      if (exactMatch !== "Other") {
+        setCustomCollege("");
+      }
+    } else {
+      setSelectedCollege("Other");
+      if (collegeSearch.trim().toLowerCase() !== "other") {
+        setCustomCollege(collegeSearch.trim());
+      }
+      setCollegeSearch("Other");
+    }
+  };
+
   const handleFormSubmit = async (e) => {
     e.preventDefault();
     setIsLoading(true);
@@ -150,13 +173,34 @@ export const Onboarding = () => {
       setIsLoading(false);
       return;
     }
-    if (!selectedCollege || selectedCollege !== collegeSearch || !collegesList.includes(selectedCollege)) {
+
+    // Normalizing college selection if user typed without selecting
+    let finalSelectedCollege = selectedCollege;
+    let finalCustomCollege = customCollege;
+    
+    if (collegeSearch.trim() && collegeSearch !== selectedCollege) {
+      const exactMatch = collegesList.find(
+        (c) => c.toLowerCase() === collegeSearch.trim().toLowerCase()
+      );
+      if (exactMatch) {
+        finalSelectedCollege = exactMatch;
+        if (exactMatch !== "Other") finalCustomCollege = "";
+      } else {
+        finalSelectedCollege = "Other";
+        finalCustomCollege = collegeSearch.trim();
+      }
+      setSelectedCollege(finalSelectedCollege);
+      setCollegeSearch(finalSelectedCollege);
+      setCustomCollege(finalCustomCollege);
+    }
+
+    if (!finalSelectedCollege || !collegesList.includes(finalSelectedCollege)) {
       setError("Please select a valid college from the searchable dropdown list.");
       setIsLoading(false);
       return;
     }
 
-    if (selectedCollege === "Other" && !customCollege.trim()) {
+    if (finalSelectedCollege === "Other" && !finalCustomCollege.trim()) {
       setError("Please specify your college name.");
       setIsLoading(false);
       return;
@@ -284,7 +328,7 @@ export const Onboarding = () => {
           gender,
           dob,
           city: city.trim(),
-          college: selectedCollege === "Other" ? customCollege.trim() : selectedCollege,
+          college: finalSelectedCollege === "Other" ? finalCustomCollege.trim() : finalSelectedCollege,
           linkedinUrl: linkedinUrl.trim() || "",
           instagramHandle: instagramHandle.trim().replace(/^@/, "") || "",
           referralCode: newReferralCode,
@@ -524,6 +568,7 @@ export const Onboarding = () => {
                   placeholder="Type to filter Mumbai colleges..."
                   value={collegeSearch}
                   onFocus={() => setShowCollegeDropdown(true)}
+                  onBlur={handleCollegeBlur}
                   onChange={(e) => {
                     setCollegeSearch(e.target.value);
                     setShowCollegeDropdown(true);
@@ -549,7 +594,10 @@ export const Onboarding = () => {
                       filteredColleges.map((col) => (
                         <div
                           key={col}
-                          onClick={() => handleSelectCollege(col)}
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            handleSelectCollege(col);
+                          }}
                           className="px-4 py-2.5 text-xs text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 cursor-pointer font-medium transition-colors"
                         >
                           {col}


### PR DESCRIPTION
### Closes #316 

## Description
This PR resolves the issue where users could bypass the autocomplete validation for the college field during onboarding. Previously, if a user typed a custom college name and clicked outside the dropdown without explicitly selecting the "Other" option, the input value would not bind to the `selectedCollege` state properly. This led to incomplete user records or failed Firestore profile document saves.

## Changes Proposed
- **Added `handleCollegeBlur` logic**: Ensures the component correctly sanitizes the input value on blur. If the user input perfectly matches a pre-defined college, it auto-selects it. If it doesn't match, it gracefully falls back by auto-selecting "Other" and pre-filling the custom college text field.
- **Improved Dropdown Interaction Focus Management**: Changed dropdown options to use `onMouseDown` combined with `e.preventDefault()` instead of `onClick`. This guarantees that selecting an option doesn't instantly blur the input field and interrupt the state update cycle.
- **Strengthened Pre-submit Normalization**: Included a final defensive normalization layer inside `handleFormSubmit` to catch extremely rapid click events and strictly enforce valid entries before a Firestore transaction executes.

## Video / Screenshots

https://github.com/user-attachments/assets/3f38e8c0-fbbb-4443-8b52-17da3dde4528



## Checklist
- [x] Verified that typing a known college and clicking away auto-selects it properly.
- [x] Verified that typing a random custom college and clicking away successfully triggers the "Other" state and custom input field.
- [x] Verified that the "Submit" validation successfully enforces a non-empty custom college field.
- [x] No warnings or errors during build/runtime related to this feature.