### PR TITLE
fix(#314): enforce server-side cooldown for GitRank sync

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -75,7 +75,15 @@ service cloud.firestore {
             ) &&
             request.resource.data.points.codingVersePoints == resource.data.points.codingVersePoints &&
             request.resource.data.points.streakPoints == resource.data.points.streakPoints &&
-            request.resource.data.points.referralPoints == resource.data.points.referralPoints
+            request.resource.data.points.referralPoints == resource.data.points.referralPoints &&
+            request.resource.data.lastSync == request.time &&
+            (
+              !("lastSync" in resource.data) || 
+              resource.data.lastSync == null || 
+              (resource.data.lastSync is string) || 
+              (resource.data.lastSync is number) ||
+              (resource.data.lastSync is timestamp && request.time.toMillis() >= resource.data.lastSync.toMillis() + 300000)
+            )
           )
         );
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -10,7 +10,8 @@ import {
   setDoc,
   updateDoc,
   onSnapshot,
-  writeBatch
+  writeBatch,
+  serverTimestamp
 } from "firebase/firestore";
 import axios from "axios";
 import { auth, db, signInWithGitHub, signOutUser } from "../lib/firebase";
@@ -386,7 +387,13 @@ export const AuthProvider = ({ children }) => {
     if (!user || !userData?.githubUsername) return;
 
     if (userData.lastSync) {
-      const lastSyncTime = new Date(userData.lastSync).getTime();
+      const getTimestamp = (val) => {
+        if (!val) return 0;
+        if (val.toMillis) return val.toMillis();
+        if (val.seconds) return val.seconds * 1000;
+        return new Date(val).getTime();
+      };
+      const lastSyncTime = getTimestamp(userData.lastSync);
       const cooldownMs = 5 * 60 * 1000;
       if (Date.now() - lastSyncTime < cooldownMs) {
         console.log("Background GitHub sync skipped: Cooldown active.");
@@ -426,7 +433,7 @@ export const AuthProvider = ({ children }) => {
         "githubStreak": ghStats.githubStreak, // Syncs live streak to Firestore
         "points.gitRankPoints": newGitRankPoints,
         "points.totalPoints": newTotalPoints,
-        "lastSync": new Date().toISOString()
+        "lastSync": serverTimestamp()
       });
 
       // Execute atomic transaction

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { Search, Filter, Star, Trophy, RefreshCw, GitCommit, Calendar, BookOpen, AlertCircle, CheckCircle2, Users, Medal } from "lucide-react";
-import { collection, query, doc, where, orderBy, limit, startAfter, onSnapshot, getDocs, runTransaction } from "firebase/firestore";
+import { collection, query, doc, where, orderBy, limit, startAfter, onSnapshot, getDocs, runTransaction, serverTimestamp } from "firebase/firestore";
 import { useSearchParams } from "react-router-dom";
 import { TableVirtuoso } from "react-virtuoso"; 
 import { db } from "../lib/firebase";
@@ -322,7 +322,7 @@ export const GitRank = () => {
           "githubStats.primaryLanguage": ghStats.primaryLanguage,
           "points.gitRankPoints": newGitRankPoints,
           "points.totalPoints": newTotalPoints,
-          "lastSync": new Date().toISOString()
+          "lastSync": serverTimestamp()
         });
       });
 
@@ -342,7 +342,14 @@ export const GitRank = () => {
     if (!userData?.lastSync) return;
 
     const checkCooldown = () => {
-      const lastSyncTime = new Date(userData.lastSync).getTime();
+      const getTimestamp = (val) => {
+        if (!val) return 0;
+        if (val.toMillis) return val.toMillis();
+        if (val.seconds) return val.seconds * 1000;
+        return new Date(val).getTime();
+      };
+      
+      const lastSyncTime = getTimestamp(userData.lastSync);
       const now = Date.now();
       const cooldownMs = 5 * 60 * 1000; // 5 minutes
       const elapsed = now - lastSyncTime;
@@ -605,7 +612,7 @@ export const GitRank = () => {
 
                 {userData?.lastSync && (
                   <span className="text-[10px] sm:text-xs text-slate-400 font-medium">
-                    Last sync: {new Date(userData.lastSync).toLocaleString()}
+                    Last sync: {new Date(userData.lastSync.toMillis ? userData.lastSync.toMillis() : (userData.lastSync.seconds ? userData.lastSync.seconds * 1000 : userData.lastSync)).toLocaleString()}
                   </span>
                 )}
               </div>


### PR DESCRIPTION
**Closes: #314**

Description:

### What does this PR do?
This PR resolves Issue #314 by migrating the 5-minute GitHub synchronization cooldown logic from the frontend to the Firestore security rules. This prevents malicious actors from bypassing the cooldown by refreshing their client or making direct database write requests.

### Key Changes:
- Server-Side Enforcement ( firestore.rules ):
  - Mandates that any GitHub sync update uses the request.time property to securely generate the lastSync field.
  - Implements a strict 300000 ms (5-minute) delay requirement utilizing request.time.toMillis() against the previous resource.data.lastSync.toMillis() .
  - Added graceful fallback validations so legacy user documents relying on ISO string timestamps or numerical representations continue to operate flawlessly until their next sync.
- Frontend Upgrades ( AuthContext.jsx & GitRank.jsx ):
  - Refactored lastSync fields to deploy serverTimestamp() during writes instead of relying on potentially skewed local client time arrays.
  - Refactored timestamp extraction logic on the frontend to smoothly handle both Timestamp objects (from serverTimestamp() ) and legacy ISO date strings to determine UI cooldown timers effectively.
### Proof of Fix / Testing Done:
- Tested performing consecutive manual writes to bypass the cooldown via client reload, which now effectively gets blocked by Firestore security rules.
- Verified that UI cooldown displays correct duration for serverTimestamp data objects.
- Confirmed the GitHub Sync successfully executes on valid 5-minute increments.