### PR TITLE
[Feature]: Dynamic GitHub Profile DevCard Generator  #350

### DIFF
--- a/api/devcard/[username].ts
+++ b/api/devcard/[username].ts
@@ -1,0 +1,183 @@
+export const config = {
+  runtime: 'edge',
+};
+
+// Theme configurations
+const themes = {
+  cyberpunk: {
+    bg: '#0D0E15',
+    border: '#00FF41',
+    textPrimary: '#00FF41',
+    textSecondary: '#008F11',
+    accent: '#FF003C',
+    gradient: 'url(#cyberpunk-grad)',
+  },
+  solarized: {
+    bg: '#002B36',
+    border: '#2AA198',
+    textPrimary: '#839496',
+    textSecondary: '#586E75',
+    accent: '#B58900',
+    gradient: 'none',
+  },
+  dark: {
+    bg: '#0D1117',
+    border: '#30363D',
+    textPrimary: '#C9D1D9',
+    textSecondary: '#8B949E',
+    accent: '#58A6FF',
+    gradient: 'none',
+  },
+  glassmorphism: {
+    bg: 'rgba(255, 255, 255, 0.1)',
+    border: 'rgba(255, 255, 255, 0.2)',
+    textPrimary: '#FFFFFF',
+    textSecondary: 'rgba(255, 255, 255, 0.7)',
+    accent: '#A78BFA',
+    gradient: 'url(#glass-grad)',
+  }
+};
+
+export default async function handler(req) {
+  try {
+    const url = new URL(req.url);
+    const parts = url.pathname.split('/');
+    const usernameParam = parts[parts.length - 1];
+    const username = decodeURIComponent(usernameParam).replace(/\.svg$/, '');
+    const themeName = url.searchParams.get('theme') || 'dark';
+    
+    const theme = themes[themeName] || themes.dark;
+    const projectId = process.env.VITE_FIREBASE_PROJECT_ID || 'rankerhub';
+
+    // Fetch user data from Firestore REST API
+    const firestoreUrl = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents:runQuery`;
+    
+    const queryPayload = {
+      structuredQuery: {
+        from: [{ collectionId: 'users' }],
+        where: {
+          fieldFilter: {
+            field: { fieldPath: 'githubUsername' },
+            op: 'EQUAL',
+            value: { stringValue: username }
+          }
+        },
+        limit: 1
+      }
+    };
+
+    const response = await fetch(firestoreUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(queryPayload)
+    });
+
+    let userData = {
+      points: { totalPoints: 0 },
+      streak: 0,
+      githubStats: { commits: 0, prs: 0 },
+      avatar: '',
+      college: ''
+    };
+    
+    let found = false;
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data && data.length > 0 && data[0].document) {
+        const docFields = data[0].document.fields;
+        found = true;
+        
+        userData.points.totalPoints = parseInt(docFields.points?.mapValue?.fields?.totalPoints?.integerValue || '0', 10);
+        userData.streak = parseInt(docFields.streak?.integerValue || '0', 10);
+        userData.githubStats.commits = parseInt(docFields.githubStats?.mapValue?.fields?.commits?.integerValue || '0', 10);
+        userData.githubStats.prs = parseInt(docFields.githubStats?.mapValue?.fields?.prs?.integerValue || '0', 10);
+        userData.avatar = docFields.avatar?.stringValue || '';
+        userData.college = docFields.college?.stringValue || '';
+      }
+    }
+
+    // Convert rank based on points (simple logic for display)
+    const rank = userData.points.totalPoints > 1000 ? 'Diamond' 
+               : userData.points.totalPoints > 500 ? 'Platinum' 
+               : userData.points.totalPoints > 200 ? 'Gold' 
+               : userData.points.totalPoints > 50 ? 'Silver' 
+               : 'Bronze';
+
+    // Calculate level
+    const level = Math.floor(userData.points.totalPoints / 100) + 1;
+
+    const svg = `
+      <svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="cyberpunk-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#000000" />
+            <stop offset="100%" stop-color="#0D0E15" />
+          </linearGradient>
+          <linearGradient id="glass-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#3b82f6" />
+            <stop offset="100%" stop-color="#8b5cf6" />
+          </linearGradient>
+          <style>
+            .title { font: bold 20px 'Inter', 'Segoe UI', Ubuntu, Sans-Serif; fill: ${theme.textPrimary}; }
+            .subtitle { font: 14px 'Inter', 'Segoe UI', Ubuntu, Sans-Serif; fill: ${theme.textSecondary}; }
+            .stat-value { font: bold 16px 'Inter', 'Segoe UI', Ubuntu, Sans-Serif; fill: ${theme.textPrimary}; }
+            .stat-label { font: 12px 'Inter', 'Segoe UI', Ubuntu, Sans-Serif; fill: ${theme.textSecondary}; }
+            .accent { fill: ${theme.accent}; font-weight: bold; }
+          </style>
+        </defs>
+        
+        <rect width="400" height="200" rx="10" ry="10" 
+              fill="${themeName === 'glassmorphism' || themeName === 'cyberpunk' ? theme.gradient : theme.bg}" 
+              stroke="${theme.border}" stroke-width="2"/>
+        
+        <!-- Header -->
+        <text x="20" y="40" class="title">${username}'s DevCard</text>
+        <text x="20" y="60" class="subtitle">RankerHub Level ${level} &bull; ${rank}</text>
+        
+        <!-- Stats Grid -->
+        <g transform="translate(20, 90)">
+          <!-- Total Points -->
+          <text x="0" y="0" class="stat-value">${userData.points.totalPoints}</text>
+          <text x="0" y="20" class="stat-label">Total Points</text>
+          
+          <!-- Streak -->
+          <text x="120" y="0" class="stat-value">${userData.streak} Days</text>
+          <text x="120" y="20" class="stat-label">Current Streak</text>
+          
+          <!-- Commits -->
+          <text x="240" y="0" class="stat-value">${userData.githubStats.commits}</text>
+          <text x="240" y="20" class="stat-label">GH Commits</text>
+          
+          <!-- PRs -->
+          <text x="0" y="55" class="stat-value">${userData.githubStats.prs}</text>
+          <text x="0" y="75" class="stat-label">Pull Requests</text>
+          
+          <!-- Status -->
+          <text x="120" y="55" class="accent">${found ? 'Active Profile' : 'Not Found'}</text>
+          <text x="120" y="75" class="stat-label">Status</text>
+        </g>
+
+        <!-- Footer -->
+        <text x="380" y="185" font-size="10" fill="${theme.textSecondary}" text-anchor="end" font-family="'Inter', sans-serif">
+          Generated dynamically by RankerHub
+        </text>
+      </svg>
+    `.trim();
+
+    return new Response(svg, {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/svg+xml',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+        'Access-Control-Allow-Origin': '*'
+      }
+    });
+  } catch (e) {
+    console.error('DevCard Error:', e);
+    return new Response('<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200"><text x="20" y="20" fill="red">Error generating devcard</text></svg>', {
+      status: 500,
+      headers: { 'Content-Type': 'image/svg+xml' }
+    });
+  }
+}

--- a/src/pages/CardBuilder.jsx
+++ b/src/pages/CardBuilder.jsx
@@ -1,0 +1,168 @@
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { Copy, Check, Download, ExternalLink } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+const themes = [
+  { id: 'dark', name: 'Dark Mode', color: '#0D1117' },
+  { id: 'cyberpunk', name: 'Cyberpunk', color: '#00FF41' },
+  { id: 'solarized', name: 'Solarized', color: '#002B36' },
+  { id: 'glassmorphism', name: 'Glassmorphism', color: '#8b5cf6' },
+];
+
+const CardBuilder = () => {
+  const { userData } = useAuth();
+  const [selectedTheme, setSelectedTheme] = useState('dark');
+  const [copied, setCopied] = useState(false);
+
+  // Fallback to "username" if no GitHub username is available during test
+  const githubUsername = userData?.githubUsername || 'RankerHubUser';
+  
+  // The base URL of the site. In production this should be the live vercel domain
+  // For local development, we'll use window.location.origin
+  const baseUrl = window.location.origin;
+  const devcardUrl = `${baseUrl}/api/devcard/${githubUsername}?theme=${selectedTheme}`;
+  
+  const markdownCode = `[![RankerHub Stats](${devcardUrl})](${baseUrl}/dashboard/profile/${githubUsername})`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(markdownCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div className="flex flex-col space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+          Developer Card Builder
+        </h1>
+        <p className="text-slate-500 dark:text-slate-400">
+          Customize your dynamic RankerHub stats card and share it on your GitHub profile README.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        
+        {/* Left Column: Controls */}
+        <div className="lg:col-span-1 space-y-6">
+          <div className="bg-white dark:bg-[#0f172a] rounded-xl border border-slate-200 dark:border-slate-800 p-6 space-y-6">
+            
+            {/* Theme Selector */}
+            <div className="space-y-4">
+              <h3 className="text-sm font-semibold text-slate-900 dark:text-white uppercase tracking-wider">
+                Select Theme
+              </h3>
+              <div className="grid grid-cols-2 gap-3">
+                {themes.map((theme) => (
+                  <button
+                    key={theme.id}
+                    onClick={() => setSelectedTheme(theme.id)}
+                    className={`flex items-center space-x-2 p-3 rounded-lg border transition-all ${
+                      selectedTheme === theme.id
+                        ? 'border-violet-500 bg-violet-50 dark:bg-violet-500/10 text-violet-700 dark:text-violet-300'
+                        : 'border-slate-200 dark:border-slate-700 hover:border-violet-300 dark:hover:border-violet-600 text-slate-700 dark:text-slate-300'
+                    }`}
+                  >
+                    <div 
+                      className="w-4 h-4 rounded-full border border-slate-300 dark:border-slate-600" 
+                      style={{ backgroundColor: theme.color }}
+                    />
+                    <span className="text-sm font-medium">{theme.name}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Markdown Export */}
+            <div className="space-y-4">
+              <h3 className="text-sm font-semibold text-slate-900 dark:text-white uppercase tracking-wider">
+                Export Markdown
+              </h3>
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Copy this code and paste it into your GitHub Profile README.md file.
+              </p>
+              
+              <div className="relative group">
+                <pre className="p-4 bg-slate-50 dark:bg-[#090D1A] rounded-lg border border-slate-200 dark:border-slate-800 text-xs text-slate-600 dark:text-slate-300 overflow-x-auto whitespace-pre-wrap break-all">
+                  {markdownCode}
+                </pre>
+                <button
+                  onClick={handleCopy}
+                  className="absolute top-2 right-2 p-2 bg-white dark:bg-slate-800 rounded-md border border-slate-200 dark:border-slate-700 shadow-sm hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors text-slate-500 dark:text-slate-400"
+                  aria-label="Copy markdown"
+                >
+                  {copied ? <Check className="w-4 h-4 text-emerald-500" /> : <Copy className="w-4 h-4" />}
+                </button>
+              </div>
+            </div>
+            
+            {/* Direct Link */}
+            <div className="space-y-4 pt-2 border-t border-slate-200 dark:border-slate-800">
+              <a 
+                href={devcardUrl} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                className="flex items-center justify-center space-x-2 w-full py-2.5 px-4 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg text-sm font-medium transition-colors"
+              >
+                <span>Open Raw SVG</span>
+                <ExternalLink className="w-4 h-4" />
+              </a>
+            </div>
+
+          </div>
+        </div>
+
+        {/* Right Column: Preview */}
+        <div className="lg:col-span-2">
+          <div className="bg-white dark:bg-[#0f172a] rounded-xl border border-slate-200 dark:border-slate-800 p-6 h-full flex flex-col">
+            <div className="flex items-center justify-between mb-6">
+              <h3 className="text-sm font-semibold text-slate-900 dark:text-white uppercase tracking-wider">
+                Live Preview
+              </h3>
+              <span className="px-2.5 py-1 bg-emerald-100 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400 text-xs font-medium rounded-full flex items-center space-x-1">
+                <span className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse"></span>
+                <span>Auto-updating</span>
+              </span>
+            </div>
+            
+            <div className="flex-1 flex items-center justify-center p-8 bg-slate-50 dark:bg-[#090D1A] rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+              <motion.div
+                key={selectedTheme}
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.3 }}
+                className="w-full max-w-md"
+              >
+                {/* 
+                  Using an <img> tag to fetch the SVG directly from the API 
+                  We append a timestamp during dev/preview to force refresh if needed,
+                  though in production standard caching is fine.
+                */}
+                <img 
+                  src={devcardUrl} 
+                  alt={`${githubUsername}'s DevCard`}
+                  className="w-full h-auto drop-shadow-xl"
+                  onError={(e) => {
+                    e.currentTarget.style.display = 'none';
+                    e.currentTarget.nextElementSibling.style.display = 'flex';
+                  }}
+                />
+                
+                {/* Fallback Error State */}
+                <div className="hidden flex-col items-center justify-center p-8 text-center text-slate-500 dark:text-slate-400">
+                  <span className="text-sm font-medium">Failed to load preview. Is the API endpoint running?</span>
+                  <p className="text-xs mt-2">Vercel API routes may not work via standard local Vite dev server without Vercel CLI.</p>
+                </div>
+              </motion.div>
+            </div>
+            
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+};
+
+export default CardBuilder;

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1102,6 +1102,9 @@ export const Profile = () => {
             <GradientButton onClick={handleDownloadProfileCard} className="py-2.5 px-4 text-xs">
               Download Profile Card
             </GradientButton>
+            <GradientButton onClick={() => window.location.href='/dashboard/profile/card-builder'} className="py-2.5 px-4 text-xs bg-gradient-to-r from-blue-500 to-indigo-500">
+              Build GitHub DevCard
+            </GradientButton>
           </>
         )}
       </SectionHeader>

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -90,6 +90,8 @@ const GuestRoute = ({ children }) => {
   return children;
 };
 
+import CardBuilder from "../pages/CardBuilder";
+
 // An inline settings page to keep route integrated
 const SettingsPage = () => (
   <div className="space-y-6">
@@ -149,6 +151,7 @@ export const AppRoutes = () => {
           <Route path="/dashboard/friends/following" element={<Friends />} />
           <Route path="/dashboard/profile" element={<Profile />} />
           <Route path="/dashboard/profile/:username" element={<Profile />} />
+          <Route path="/dashboard/profile/card-builder" element={<CardBuilder />} />
           <Route path="/dashboard/settings" element={<SettingsPage />} />
         </Route>
 


### PR DESCRIPTION
## Fixes Issue
Resolves #[Feature]: Dynamic GitHub Profile DevCard Generator  #350

## Description
This PR implements the requested Dynamic GitHub Profile DevCard Generator, allowing users to embed live, auto-updating SVGs of their RankerHub stats directly into their GitHub Profile README.

### Key Features Implemented:
- **Serverless API Endpoint (`api/devcard/[username].ts`)**: A high-performance edge function that dynamically fetches user data from Firestore and renders a clean SVG without hitting browser CORS restrictions.
- **Card Builder Dashboard (`/dashboard/profile/card-builder`)**: A new frontend UI under the Dashboard where users can preview their DevCard.
- **Multiple Theme Engine**: Added 4 distinct styles (`dark`, `cyberpunk`, `solarized`, and `glassmorphism`) that users can toggle between.
- **Markdown Export**: Users can copy the generated markdown code in one click to paste onto their GitHub profile.
- **Profile Integration**: Added a "Build GitHub DevCard" button to the user's Profile page for easy feature discovery.

## Testing Guidelines
- Open the `/dashboard/profile` route and ensure the new button exists.
- Click the button to navigate to the Card Builder.
- Test toggling between different themes and ensure the SVG URL changes accordingly.
- Copy the Markdown block and paste it into a markdown previewer (or GitHub repo README) to verify the image renders correctly.


<img width="400" height="200" alt="preview" src="https://github.com/user-attachments/assets/ee0d301d-1d45-49bc-9040-8bfe5892e29a" />
