### PR TITLE
fix: enforce strict per-write bounds and field locks in streak rules (#360)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -28,7 +28,15 @@ service cloud.firestore {
       return affected.hasOnly(streakFields)
         && request.resource.data.longestStreak >= resource.data.longestStreak
         && request.resource.data.streak >= 0
-        && request.resource.data.points.streakPoints >= resource.data.points.streakPoints;
+        && request.resource.data.points.streakPoints >= resource.data.points.streakPoints
+        // FIXED: Enforce a maximum of +10 streakPoints per write (Issue #360)
+        && (request.resource.data.points.streakPoints - resource.data.points.streakPoints <= 10)
+        // STRICT CAP: totalPoints must increase by the EXACT same delta as streakPoints
+        && (request.resource.data.points.totalPoints - resource.data.points.totalPoints == request.resource.data.points.streakPoints - resource.data.points.streakPoints)
+        // PREVENT TAMPERING: Other points must remain frozen during a streak update
+        && request.resource.data.points.gitRankPoints == resource.data.points.gitRankPoints
+        && request.resource.data.points.codingVersePoints == resource.data.points.codingVersePoints
+        && request.resource.data.points.referralPoints == resource.data.points.referralPoints;
     }
 
     match /users/{uid} {


### PR DESCRIPTION
### Description
This PR resolves a critical vulnerability in `firestore.rules` where malicious actors could completely bypass the main `200 XP` limits by exploiting the `isStreakUpdate()` helper function via direct Firestore SDK writes. 

### Key Changes
* **Implemented Hard Cap:** `streakPoints` is now strictly limited to a maximum increment of `+10` points per transaction, aligning with the platform's official spec.
* **Secured Total Points Delta:** The `totalPoints` increment is now mathematically locked to exactly match the `streakPoints` increment (`totalPoints_new - totalPoints_old == streakPoints_new - streakPoints_old`), preventing mixed-field point inflation.
* **Tamper Prevention (Field Freezing):** Explicitly locked `gitRankPoints`, `codingVersePoints`, and `referralPoints` during a streak check-in to ensure these buckets cannot be silently manipulated in the same request.

### Impact & Testing
* Closes the unbounded point inflation loophole.
* Syntax has been carefully validated to ensure it does not break existing Firebase Emulator CI checks or valid UI-driven check-ins.

Fixes #360