### PR TITLE
fix: loosen CSP to allow raw github avatars and google analytics scripts

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.firebaseapp.com https://apis.google.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://api.github.com; img-src 'self' data: blob: https://avatars.githubusercontent.com https://*.googleusercontent.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://*.firebaseapp.com;" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.firebaseapp.com https://apis.google.com https://www.googletagmanager.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://api.github.com https://www.google-analytics.com; img-src 'self' data: blob: https://avatars.githubusercontent.com https://*.googleusercontent.com https://github.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://*.firebaseapp.com;" }
       ]
     }
   ]


### PR DESCRIPTION
### Description
This hotfix opens up the tight CSP configuration deployed in the previous security lifecycle release. It whitelists essential core paths required for non-breaking UI rendering and site metrics tracking.

### Key Changes
* **`img-src` Expansion:** Appended `https://github.com` to allow direct, un-proxied user avatars to render across About and Contributor blocks safely.
* **Analytics Integration:** Whitelisted `https://www.googletagmanager.com` (`script-src`) and `https://www.google-analytics.com` (`connect-src`) to unblock production script delivery.

Closes #398 