### PR TITLE
[NSOC'26][GSSOC'26]Fix: restrict referral update rule to points field only

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -101,6 +101,8 @@ service cloud.firestore {
       // Locks referralPoints to the actual totalEarned value in the referrals index.
       allow update: if isAuthenticated()
         && request.auth.uid != uid
+        // Prevent modifying any root-level fields other than points
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['points'])
         // FIX: Sync referralPoints directly with the referrals index document's totalEarned counter
         && request.resource.data.points.referralPoints == get(/databases/$(database)/documents/referrals/$(uid)).data.totalEarned
         // FIX: Total points must reflect the exact growth in referral points


### PR DESCRIPTION
# Pull Request Template 🚀

## Description
This PR addresses a critical access control vulnerability in the Firestore Security Rules. 

### Context & Flaw
Rule 4 in `firestore.rules` (the referrer update rule) allows any authenticated user who is not the owner (`request.auth.uid != uid`) to write updates to the referrer's user document during the onboarding referral process. While the rule correctly validated points-related fields and froze other types of points (`gitRankPoints`, `codingVersePoints`, `streakPoints`, etc.), it lacked any restriction on what **root-level** fields could be modified. This allowed a malicious client to modify key profile properties of another developer (e.g., `name`, `githubUsername`, `avatar`, or `bio`) during a referral points transaction.

### Fix
Added a condition to Rule 4 restricting the modified fields on the target document strictly to the `points` root-level object:
`&& request.resource.data.diff(resource.data).affectedKeys().hasOnly(['points'])`

This aligns with client updates performed in `Onboarding.jsx` (which only touch `points.referralPoints` and `points.totalPoints`) while completely securing other root-level profile attributes from privilege escalation/unauthorized updates.

## Related Issue
Closes #383

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
N/A (Back-end database rules change, no UI/visual updates)

## Testing Done
- [x] Command run: `npm run test` (Passed successfully: 26/26 tests passed)
- [x] Command run: `npm run lint` (Passed successfully: clean ESLint check)
- [x] Command run: `npm run build` (Passed successfully: clean Vite production build)

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] New and existing unit tests pass locally with my changes.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **GSSoC 2026** and **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the [Contributing Guidelines](https://github.com/indresh404/RankerHub/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://github.com/indresh404/RankerHub/blob/main/docs/CODE_OF_CONDUCT.md).
