### PR TITLE
[NSOC'26][GSSOC'26]Sec(rules): Prevent points injection during daily streak updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -25,19 +25,16 @@ service cloud.firestore {
     function isStreakUpdate() {
       let affected = request.resource.data.diff(resource.data).affectedKeys();
       let streakFields = ['streak', 'longestStreak', 'lastLogin', 'points'];
+      let pointsAffected = request.resource.data.points.diff(resource.data.points).affectedKeys();
       return affected.hasOnly(streakFields)
+        && pointsAffected.hasOnly(['streakPoints', 'totalPoints'])
         && request.resource.data.longestStreak >= resource.data.longestStreak
         && request.resource.data.streak >= 0
         && request.resource.data.points.streakPoints >= resource.data.points.streakPoints
         // FIXED: Enforce a maximum of +10 streakPoints per write (Issue #360)
         && (request.resource.data.points.streakPoints - resource.data.points.streakPoints <= 10)
         // STRICT CAP: totalPoints must increase by the EXACT same delta as streakPoints
-        && (request.resource.data.points.totalPoints - resource.data.points.totalPoints == request.resource.data.points.streakPoints - resource.data.points.streakPoints)
-        // PREVENT TAMPERING: Other points must remain frozen during a streak update
-        && request.resource.data.points.gitRankPoints == resource.data.points.gitRankPoints
-        && request.resource.data.points.codingVersePoints == resource.data.points.codingVersePoints
-        && request.resource.data.points.referralPoints == resource.data.points.referralPoints
-        && request.resource.data.points.auditorPoints == resource.data.points.auditorPoints;
+        && (request.resource.data.points.totalPoints - resource.data.points.totalPoints == request.resource.data.points.streakPoints - resource.data.points.streakPoints);
     }
 
     match /users/{uid} {


### PR DESCRIPTION
# Pull Request Template 🚀

## Description
This PR addresses a security vulnerability within the daily streak check-in Firestore rules helper function. Previously, the top-level keys diff allowed updates to the nested `points` map, but the individual sub-field checks were susceptible to bypasses (e.g. if fields were deleted, missing from legacy user profiles, or if new fields were added). 

This solution uses Map-level diffing via Firestore's `diff().affectedKeys()` to explicitly restrict any changes within the `points` map to only `streakPoints` and `totalPoints`, securely freezing all other point properties during daily check-in operations.

## Related Issue
Closes #384

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Screenshots / Videos (if applicable)
*N/A (Backend Security Rules changes only; no UI/visual changes)*

## Testing Done
- [x] Command run: `npm run test` (All 26 unit tests passed)
- [x] Command run: `npm run lint` (ESLint output verified clean with 0 warnings/errors)
- [ ] Command run: `npm run build`
- [ ] Visual verification on local dev server (`http://localhost:5173`)

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **GSSoC 2026** and **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the [Contributing Guidelines](https://github.com/indresh404/RankerHub/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://github.com/indresh404/RankerHub/blob/main/docs/CODE_OF_CONDUCT.md).

---

> Thank you for contributing! Maintainers will review your PR soon.
