### PR TITLE
fix: remove hardcoded whitelist achievement unlock logic

### DIFF
--- a/src/pages/Achievements.jsx
+++ b/src/pages/Achievements.jsx
@@ -66,7 +66,7 @@ export const Achievements = () => {
 
   // Calculate dynamic progress mapping for the 4 badges
   const badgeProgress = {
-    b1: { unlocked: true, unlockedAt: "May 10, 2026", progress: 100, current: 1, target: 1, label: "First 100 users whitelist" },
+    b1: { unlocked: false, unlockedAt: null, progress: 0, current: 0, target: 1, label: "First 100 users whitelist" },
     b2: { 
       unlocked: commits >= 100, 
       unlockedAt: commits >= 100 ? "Verified" : null, 


### PR DESCRIPTION
## Description

Fixed the hardcoded unlock state of the Whitelist achievement badge.

### Changes Made

- Removed automatic badge unlock (`unlocked: true`)
- Removed hardcoded unlock date
- Reset badge progress to 0%
- Kept the badge locked by default until proper whitelist validation is implemented

### Impact

Prevents users from receiving the Whitelist badge without actually meeting the whitelist requirement, preserving achievement system accuracy.

Closes #390 