### PR TITLE
fix(cache): correctly merge fields into data object in FirestoreCache…

### DIFF
--- a/src/__tests__/firestoreOptimization.test.js
+++ b/src/__tests__/firestoreOptimization.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FirestoreCache } from "../utils/firestoreOptimization";
+
+describe("FirestoreCache", () => {
+  let cache;
+
+  beforeEach(() => {
+    cache = new FirestoreCache(1000); // 1 second TTL
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should store and retrieve data correctly", () => {
+    const data = { name: "Alice", role: "Developer" };
+    cache.set("users/123", data);
+
+    expect(cache.get("users/123")).toEqual(data);
+  });
+
+  it("should return null for expired documents", () => {
+    const data = { name: "Bob" };
+    cache.set("users/456", data);
+
+    // Fast-forward time past 1 second TTL
+    vi.advanceTimersByTime(1500);
+
+    expect(cache.get("users/456")).toBeNull();
+  });
+
+  it("should merge fields correctly inside data wrapper on update", () => {
+    const originalData = { name: "Charlie", score: 10, skills: ["JS"] };
+    cache.set("users/789", originalData);
+
+    // Update specific fields
+    cache.update("users/789", { score: 20, active: true });
+
+    const cachedEntry = cache.cache.get("users/789");
+    // Verify cache entry structure is preserved (data wrapper + timestamp)
+    expect(cachedEntry).toHaveProperty("data");
+    expect(cachedEntry).toHaveProperty("timestamp");
+    expect(cachedEntry.timestamp).toBeTypeOf("number");
+
+    // Verify underlying data was merged properly
+    expect(cachedEntry.data).toEqual({
+      name: "Charlie",
+      score: 20,
+      skills: ["JS"],
+      active: true
+    });
+
+    // Verify retrieval
+    expect(cache.get("users/789")).toEqual({
+      name: "Charlie",
+      score: 20,
+      skills: ["JS"],
+      active: true
+    });
+  });
+
+  it("should delete entry", () => {
+    cache.set("users/123", { val: 1 });
+    cache.delete("users/123");
+    expect(cache.get("users/123")).toBeNull();
+  });
+
+  it("should clear all entries", () => {
+    cache.set("a", { val: 1 });
+    cache.set("b", { val: 2 });
+    cache.clear();
+    expect(cache.size()).toBe(0);
+  });
+});

--- a/src/utils/firestoreOptimization.js
+++ b/src/utils/firestoreOptimization.js
@@ -46,8 +46,8 @@ export class FirestoreCache {
     const cached = this.cache.get(docPath);
     if (!cached) return;
 
-    const updated = { ...cached, ...fields };
-    this.set(docPath, updated);
+    const updatedData = { ...cached.data, ...fields };
+    this.set(docPath, updatedData);
   }
 
   /**


### PR DESCRIPTION


## Description
This pull request fixes a data structure merging bug inside our `FirestoreCache` utility class that was causing cache corruption and leaking cache wrapper metadata.

In `src/utils/firestoreOptimization.js`, the `update` method in the `FirestoreCache` class was merging update attributes directly into the root level of the cache wrapper object (doing `{ ...cached, ...fields }` where `cached` is `{ data, timestamp }`). This caused user-profile properties to be stored at the top level of the cache entries, and left the nested `.data` object unchanged.

To resolve this, we have:
1. Refactored the `update` method to specifically target and merge properties inside the `cached.data` object before storing the updated entry with a refreshed timestamp.
2. Created a dedicated unit test suite at `src/__tests__/firestoreOptimization.test.js` asserting caching operations, TTL expiration events, and nested structure preservation during updates.

## Related Issue
Fixes #408 

## Type of Change
- [x] Bug fix 


## Testing Done
- [x] Command run: `npm run test`
- [x] Command run: `npm run lint`
- [x] Command run: `npm run build`


**Test Output:**
```bash
 RUN  v4.1.8 C:/Users/hp/RankerHub

 ✓ src/__tests__/referral.test.js (5 tests) 28ms
 ✓ src/utils/motion.test.js (8 tests) 37ms
 ✓ src/__tests__/firestoreOptimization.test.js (5 tests) 45ms
 ✓ src/__tests__/streakCalculator.test.js (5 tests) 33ms
 ✓ src/__tests__/pointsEngine.test.js (8 tests) 24ms

 Test Files  5 passed (5)
      Tests  31 passed (31)
