### PR TITLE
fix(batch): instantiate writeBatch dynamically in flush if missing to…

### DIFF
--- a/src/__tests__/firestoreBatchOptimizer.test.js
+++ b/src/__tests__/firestoreBatchOptimizer.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FirestoreBatchOptimizer } from "../utils/firestoreOptimization";
+import * as firestoreSdk from "firebase/firestore";
+
+// Mock firebase/firestore
+vi.mock("firebase/firestore", () => {
+  return {
+    writeBatch: vi.fn()
+  };
+});
+
+// Mock database
+vi.mock("../lib/firebase", () => {
+  return {
+    db: {}
+  };
+});
+
+describe("FirestoreBatchOptimizer", () => {
+  let mockBatch;
+
+  beforeEach(() => {
+    mockBatch = {
+      set: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      commit: vi.fn().mockResolvedValue()
+    };
+    firestoreSdk.writeBatch.mockReturnValue(mockBatch);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("should delay flushing based on interval", async () => {
+    const optimizer = new FirestoreBatchOptimizer(500, 5);
+    optimizer.add({ type: "set", docRef: "ref1", data: { x: 1 } });
+
+    // Shouldn't flush immediately
+    expect(optimizer.batch.length).toBe(1);
+    expect(mockBatch.commit).not.toHaveBeenCalled();
+
+    // Advance timer past 500ms
+    vi.advanceTimersByTime(600);
+
+    // Verify flush was called
+    expect(optimizer.batch.length).toBe(0);
+    expect(mockBatch.set).toHaveBeenCalledWith("ref1", { x: 1 }, undefined);
+    expect(mockBatch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should flush immediately when maxBatchSize is reached", () => {
+    const optimizer = new FirestoreBatchOptimizer(1000, 3);
+    optimizer.add({ type: "set", docRef: "r1", data: { v: 1 } });
+    optimizer.add({ type: "update", docRef: "r2", data: { v: 2 } });
+    
+    expect(optimizer.batch.length).toBe(2);
+    expect(mockBatch.commit).not.toHaveBeenCalled();
+
+    // The third one should trigger immediate flush
+    optimizer.add({ type: "delete", docRef: "r3" });
+
+    expect(optimizer.batch.length).toBe(0);
+    expect(mockBatch.set).toHaveBeenCalledWith("r1", { v: 1 }, undefined);
+    expect(mockBatch.update).toHaveBeenCalledWith("r2", { v: 2 });
+    expect(mockBatch.delete).toHaveBeenCalledWith("r3");
+    expect(mockBatch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should re-queue failed operations when commit throws an error", async () => {
+    mockBatch.commit.mockRejectedValue(new Error("Firebase Transaction Conflict"));
+    const optimizer = new FirestoreBatchOptimizer(1000, 2);
+    optimizer.add({ type: "set", docRef: "r1", data: { v: 1 } });
+
+    // Force flush
+    await expect(optimizer.flush()).rejects.toThrow("Firebase Transaction Conflict");
+
+    // Operations should be put back in the queue
+    expect(optimizer.batch.length).toBe(1);
+    expect(optimizer.batch[0].docRef).toBe("r1");
+  });
+});

--- a/src/utils/firestoreOptimization.js
+++ b/src/utils/firestoreOptimization.js
@@ -3,6 +3,9 @@
  * Implements caching strategies and pagination to reduce database reads
  */
 
+import { writeBatch } from "firebase/firestore";
+import { db } from "../lib/firebase";
+
 /**
  * Simple in-memory cache for Firestore documents
  * Reduces repeated reads for the same document
@@ -161,7 +164,7 @@ export class FirestoreBatchOptimizer {
   /**
    * Flush batch operations
    */
-  async flush(writeBatch) {
+  async flush(writeBatchInstance) {
     if (this.timeoutId) {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;
@@ -174,18 +177,23 @@ export class FirestoreBatchOptimizer {
     const operationsToCommit = [...this.batch];
     this.batch = [];
 
-    if (writeBatch) {
+    let activeBatch = writeBatchInstance;
+    if (!activeBatch && db && typeof writeBatch === "function") {
+      activeBatch = writeBatch(db);
+    }
+
+    if (activeBatch) {
       try {
         for (const op of operationsToCommit) {
           if (op.type === 'set') {
-            writeBatch.set(op.docRef, op.data, op.options);
+            activeBatch.set(op.docRef, op.data, op.options);
           } else if (op.type === 'update') {
-            writeBatch.update(op.docRef, op.data);
+            activeBatch.update(op.docRef, op.data);
           } else if (op.type === 'delete') {
-            writeBatch.delete(op.docRef);
+            activeBatch.delete(op.docRef);
           }
         }
-        await writeBatch.commit();
+        await activeBatch.commit();
       } catch (error) {
         // Re-queue failed operations
         this.batch = operationsToCommit;


### PR DESCRIPTION


## Description
This pull request resolves a critical data-loss bug in `FirestoreBatchOptimizer` where batched operations were silently discarded upon auto-flush.

In `src/utils/firestoreOptimization.js`, `FirestoreBatchOptimizer.add()` automatically triggers `this.flush()` when the batch queue reaches `maxBatchSize` or when a scheduled flush timeout fires. However, `flush(writeBatch)` expects a write batch instance to be passed as a parameter. Because the internal scheduler calls `this.flush()` without any arguments, the write batch was undefined, leading to operations being popped off the queue and cleared without ever being committed to Firestore.

To resolve this, we have:
1. Imported `writeBatch` and `db` into `src/utils/firestoreOptimization.js`.
2. Refactored the `flush` method to dynamically initialize an active write batch using `writeBatch(db)` if one is not passed as an argument.
3. Created a dedicated unit test suite at `src/__tests__/firestoreBatchOptimizer.test.js` verifying interval scheduling, auto-flushing limits, and operation re-queuing upon commit failure.

## Related Issue
Fixes #409 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


## Testing Done
- [x] Command run: `npm run test`
- [x] Command run: `npm run lint`
- [x] Command run: `npm run build`
- [ ] Visual verification on local dev server (`http://localhost:5173`)

**Test Output:**
```bash
 RUN  v4.1.8 C:/Users/hp/RankerHub

 ✓ src/__tests__/streakCalculator.test.js (5 tests) 39ms
 ✓ src/utils/motion.test.js (8 tests) 116ms
 ✓ src/__tests__/firestoreBatchOptimizer.test.js (3 tests) 192ms
 ✓ src/__tests__/referral.test.js (5 tests) 29ms
 ✓ src/__tests__/pointsEngine.test.js (8 tests) 19ms

 Test Files  5 passed (5)
      Tests  29 passed (29)
