### PR TITLE
fix: deduplicate search suggestions in getSearchSuggestions using Map

### DIFF
--- a/src/__tests__/searchUtils.test.js
+++ b/src/__tests__/searchUtils.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  searchLeaderboard,
+  filterByLanguage,
+  filterByRole,
+  getSearchSuggestions
+} from "../utils/searchUtils";
+
+// Mock the leaderboard data modules since they are empty in main
+vi.mock("../data/leaderboard", () => {
+  return {
+    leaderboardData: [
+      { name: "Alice Smith", username: "alice", role: "Frontend Developer", language: "JavaScript" },
+      { name: "Bob Johnson", username: "bob", role: "Backend Developer", language: "Python" }
+    ],
+    womenLeaderboardData: [
+      { name: "Clara Davis", username: "clara", role: "Engineering Lead", language: "Go" }
+    ]
+  };
+});
+
+describe("searchUtils", () => {
+  describe("searchLeaderboard", () => {
+    it("should return matches from leaderboardData", () => {
+      const results = searchLeaderboard("alice");
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("Alice Smith");
+    });
+
+    it("should include womenLeaderboardData if requested", () => {
+      const results = searchLeaderboard("clara", true);
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("Clara Davis");
+    });
+
+    it("should be null-safe when user fields are missing", () => {
+      // Temporarily mock the module data for testing incomplete data
+      vi.doMock("../data/leaderboard", () => {
+        return {
+          leaderboardData: [
+            { name: null, username: "usernameonly", role: "Dev" },
+            { name: "NoUsername", username: undefined, role: "Dev" }
+          ],
+          womenLeaderboardData: []
+        };
+      });
+
+      // It should execute without throwing type errors
+      expect(() => searchLeaderboard("username")).not.toThrow();
+      expect(() => searchLeaderboard("no")).not.toThrow();
+    });
+  });
+
+  describe("getSearchSuggestions", () => {
+    const users = [
+      { name: "Alice Smith", username: "alice" },
+      { name: "Bob Jones", username: "bob" },
+      { name: undefined, username: "guest123" },
+      { name: "Guest User", username: null }
+    ];
+
+    it("should generate suggestions based on partial input", () => {
+      const suggestions = getSearchSuggestions(users, "al");
+      expect(suggestions.length).toBe(2);
+      expect(suggestions[0].value).toBe("Alice Smith");
+      expect(suggestions[1].value).toBe("alice");
+    });
+
+    it("should be null-safe and skip missing fields without crashing", () => {
+      expect(() => getSearchSuggestions(users, "guest")).not.toThrow();
+      const suggestions = getSearchSuggestions(users, "guest");
+      // Guest User match
+      expect(suggestions.some(s => s.value === "Guest User")).toBe(true);
+    });
+
+    it("should prevent duplicate suggestions when multiple users match the same suggestion value", () => {
+      const usersWithDupes = [
+        { name: "Alice Smith", username: "alice", language: "JavaScript" },
+        { name: "Alice Smith", username: "alice2", language: "JavaScript" },
+        { name: "Bob Jones", username: "bob", language: "Python" }
+      ];
+      // Search for language "JavaScript" where multiple users have it
+      const suggestions = getSearchSuggestions(usersWithDupes, "java");
+      const jsSuggestions = suggestions.filter(s => s.type === "language");
+      expect(jsSuggestions.length).toBe(1);
+      expect(jsSuggestions[0].value).toBe("JavaScript");
+
+      // Search for name "Alice Smith" where multiple users share the name
+      const nameSuggestions = getSearchSuggestions(usersWithDupes, "alice");
+      const nameMatches = nameSuggestions.filter(s => s.type === "name");
+      expect(nameMatches.length).toBe(1);
+      expect(nameMatches[0].display).toBe("Alice Smith (@alice)"); // First occurrence is preserved
+    });
+  });
+
+  describe("filterByLanguage and filterByRole", () => {
+    const users = [
+      { name: "Alice", language: "JavaScript", role: "Frontend" },
+      { name: "Bob", language: "Python", role: "Backend" }
+    ];
+
+    it("should filter by language", () => {
+      const jsUsers = filterByLanguage(users, "JavaScript");
+      expect(jsUsers.length).toBe(1);
+      expect(jsUsers[0].name).toBe("Alice");
+    });
+
+    it("should filter by role", () => {
+      const backendUsers = filterByRole(users, "backend");
+      expect(backendUsers.length).toBe(1);
+      expect(backendUsers[0].name).toBe("Bob");
+    });
+  });
+});

--- a/src/utils/searchUtils.js
+++ b/src/utils/searchUtils.js
@@ -127,31 +127,43 @@ export const getSearchSuggestions = (users, query) => {
   if (!query || query.trim().length < 1) return [];
 
   const searchTerm = query.toLowerCase().trim();
-  const suggestions = new Set();
+  const suggestionsMap = new Map();
 
   users.forEach((user) => {
-    if (user.name.toLowerCase().startsWith(searchTerm)) {
-      suggestions.add({
-        type: "name",
-        value: user.name,
-        display: `${user.name} (@${user.username})`
-      });
+    const name = user.name || "";
+    const username = user.username || "";
+
+    if (name.toLowerCase().startsWith(searchTerm)) {
+      const key = `name:${name}`;
+      if (!suggestionsMap.has(key)) {
+        suggestionsMap.set(key, {
+          type: "name",
+          value: name,
+          display: `${name} (@${username})`
+        });
+      }
     }
-    if (user.username.toLowerCase().startsWith(searchTerm)) {
-      suggestions.add({
-        type: "username",
-        value: user.username,
-        display: `@${user.username}`
-      });
+    if (username.toLowerCase().startsWith(searchTerm)) {
+      const key = `username:${username}`;
+      if (!suggestionsMap.has(key)) {
+        suggestionsMap.set(key, {
+          type: "username",
+          value: username,
+          display: `@${username}`
+        });
+      }
     }
     if (user.language && user.language.toLowerCase().includes(searchTerm)) {
-      suggestions.add({
-        type: "language",
-        value: user.language,
-        display: `Language: ${user.language}`
-      });
+      const key = `language:${user.language}`;
+      if (!suggestionsMap.has(key)) {
+        suggestionsMap.set(key, {
+          type: "language",
+          value: user.language,
+          display: `Language: ${user.language}`
+        });
+      }
     }
   });
 
-  return Array.from(suggestions).slice(0, 5);
+  return Array.from(suggestionsMap.values()).slice(0, 5);
 };


### PR DESCRIPTION


## Description
In `searchUtils.js`, `getSearchSuggestions` was instantiating a `Set` and adding object literals (`{ type, value, display }`). In JavaScript, object literals are evaluated and compared by reference, which prevented the `Set` from performing value-based uniqueness checks. This allowed duplicate search suggestions to populate the dropdown.

To fix this, the function now utilizes a `Map` where keys represent unique suggestions formatted as `` `type:value` `` (e.g. `` `name:${name}` ``). Suggestions are only added to the Map if the key is not already present, ensuring true uniqueness. Finally, the structure is converted back into an array using `Array.from(suggestionsMap.values())`.

## Related Issue
Fixes #411

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


## Testing Done
- [x] Command run: `npm run test`
- [x] Command run: `npm run lint`
- [x] Command run: `npm run build`


## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.


## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **GSSoC 2026** and **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the [Contributing Guidelines](https://github.com/indresh404/RankerHub/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://github.com/indresh404/RankerHub/blob/main/docs/CODE_OF_CONDUCT.md).
```