### PR TITLE
fix: store github oauth token in sessionStorage for api consumers

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -122,7 +122,12 @@ export const AuthProvider = ({ children }) => {
           const accessToken = credential?.accessToken || null;
           if (accessToken) {
             setGhAccessToken(accessToken);
-          }
+
+            sessionStorage.setItem(
+            `gh_token_${authUser.uid}`,
+            accessToken
+          );
+}
 
           const additionalInfo = getAdditionalUserInfo(result);
           const githubUsername = (additionalInfo?.username || authUser.displayName || "").trim();
@@ -263,10 +268,13 @@ export const AuthProvider = ({ children }) => {
       const sanitizedUserData = validation.sanitized;
       const githubId = additionalInfo?.profile?.id || null;
 
-      // Store token only in memory for current session
-      // Firebase Auth handles persistent session via secure HTTP-only cookies
-      // Token is not persisted to localStorage or sessionStorage to prevent XSS theft
+      // Store token for authenticated GitHub API requests
       setGhAccessToken(accessToken);
+
+      sessionStorage.setItem(
+        `gh_token_${authUser.uid}`,
+        accessToken
+      );
 
       const userDocRef = doc(db, "users", authUser.uid);
       const docSnap = await getDoc(userDocRef);
@@ -364,6 +372,9 @@ export const AuthProvider = ({ children }) => {
       // No need to remove from storage since token is only in memory
       // Firebase Auth session will be cleared by signOutUser()
       await signOutUser();
+      if (user?.uid) {
+        sessionStorage.removeItem(`gh_token_${user.uid}`);
+      }
       setUser(null);
       setUserData(null);
       setIsOnboarding(false);


### PR DESCRIPTION
## Description

Fixed the GitHub OAuth token integration mismatch between AuthContext and GitHub API consumers.

### Changes Made

* Persist GitHub OAuth token to sessionStorage after successful authentication
* Remove token from sessionStorage during logout
* Updated token storage flow to match existing GitRank and Matchmaker token retrieval logic

### Impact

GitRank and Matchmaker can now retrieve a valid GitHub OAuth token and make authenticated GitHub API requests instead of falling back to unauthenticated requests.

This prevents users from quickly hitting GitHub's unauthenticated rate limit and restores expected API behavior.

Closes #387 