### PR TITLE
fix: resolve horizontal scroll overflow on mobile devices (#378)

### DIFF
--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -35,8 +35,8 @@ function CardComponent(props, ref) {
         ["--mouse-x"]: `${mouseCoords.x}px`,
         ["--mouse-y"]: `${mouseCoords.y}px`
       }}
-      className={`
-        relative backdrop-blur-xl bg-white/70 dark:bg-slate-900/70
+    className={`
+        relative max-w-full overflow-hidden break-words backdrop-blur-xl bg-white/70 dark:bg-slate-900/70
         border border-slate-200/50 dark:border-slate-800/50
         rounded-2xl p-6 shadow-md transition-colors duration-300
         ${glow && onClick ? "hover:shadow-[0_0_25px_rgba(124,58,237,0.15)] dark:hover:shadow-[0_0_25px_rgba(124,58,237,0.1)]" : ""}

--- a/src/layouts/DashboardLayout.jsx
+++ b/src/layouts/DashboardLayout.jsx
@@ -16,7 +16,7 @@ export const DashboardLayout = () => {
   } = useSidebar();
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 text-slate-800 dark:text-slate-100 transition-colors duration-300 relative overflow-hidden flex">
+    <div className="min-h-screen w-full max-w-[100vw] overflow-x-hidden bg-slate-50 dark:bg-slate-950 text-slate-800 dark:text-slate-100 transition-colors duration-300 relative flex">
       {/* Background Premium Animated Blobs (optimized with radial gradients instead of expensive blur filters) */}
       <div className="absolute top-10 left-10 w-72 h-72 md:w-96 md:h-96 bg-blob-purple pointer-events-none animate-blob -z-10 transform-gpu" />
       <div className="absolute top-1/3 right-10 w-72 h-72 md:w-96 md:h-96 bg-blob-indigo pointer-events-none animate-blob [animation-delay:2s] -z-10 transform-gpu" />


### PR DESCRIPTION
## Description
This PR addresses a UI bug where a horizontal scrollbar would appear on small mobile devices (under 380px width), allowing the user to accidentally pan the screen left and right. 

To fix this, I updated the main layout and card containers to strictly respect the mobile viewport:
- **`src/layouts/DashboardLayout.jsx`**: Added `max-w-[100vw]` and `overflow-x-hidden` to the main wrapper to enforce a rigid frame.
- **`src/components/ui/Card.jsx`**: Added `max-w-full`, `overflow-hidden`, and `break-words` so that long, unbroken text strings (like repository names or emails) wrap gracefully instead of pushing the card width beyond the screen.

## Related Issue
Closes #378

## Type of Change
Please delete options that are not relevant:
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
*Visual change:* The horizontal scrollbar is no longer triggered on mobile views. The layout is firmly locked to vertical scrolling only.

## Testing Done
I verified the layout constraints using Chrome DevTools Mobile Emulation set to iPhone SE (375px) and smaller custom widths (320px). The horizontal panning issue is completely resolved and the cards scale properly.

- [x] Command run: `node fix_lint.mjs` / `npm run lint`
- [x] Visual verification on local dev server (`http://localhost:5173`)

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **GSSoC 2026** and **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the [Contributing Guidelines](https://github.com/indresh404/RankerHub/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://github.com/indresh404/RankerHub/blob/main/docs/CODE_OF_CONDUCT.md).