### PR TITLE
fix: remove duplicate streak award in login(), delegate to checkAndUpdateStreak transaction

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -271,13 +271,10 @@ export const AuthProvider = ({ children }) => {
       const userDocRef = doc(db, "users", authUser.uid);
       const docSnap = await getDoc(userDocRef);
 
-      // Issue #191: Strict Timezone-Agnostic UTC Streak Calculation
       const today = new Date();
-      const todayUTCStr = today.toISOString().split('T')[0]; // Format: YYYY-MM-DD
-      const todayUTC = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
 
       if (!docSnap.exists()) {
-        // First login ever
+        // First login ever — initialize user document with base streak
         const skeletalUser = {
           uid: authUser.uid,
           githubUsername: sanitizedUserData.githubUsername,
@@ -288,7 +285,7 @@ export const AuthProvider = ({ children }) => {
           onboardingStatus: "incomplete",
           privateRepoSyncEnabled: requestRepoScope,
           city: "",
-          streak: 1, // Start streak
+          streak: 1,
           longestStreak: 0,
           githubStreak: 0,
           lastLogin: today.toISOString(),
@@ -308,44 +305,12 @@ export const AuthProvider = ({ children }) => {
         };
         await setDoc(userDocRef, skeletalUser);
       } else {
-        // Existing user: Calculate streak safely
-        const existingData = docSnap.data();
-        let newStreak = existingData.streak || 0;
-        let newStreakPoints = existingData.points?.streakPoints || 0;
-        let newTotalPoints = existingData.points?.totalPoints || 0;
-
-        const lastLoginDate = existingData.lastLogin ? new Date(existingData.lastLogin) : null;
-
-        if (lastLoginDate) {
-          const lastLoginUTCStr = lastLoginDate.toISOString().split('T')[0];
-
-          // Only process streak logic if it's a completely new UTC day
-          if (todayUTCStr !== lastLoginUTCStr) {
-            const lastUTC = Date.UTC(lastLoginDate.getUTCFullYear(), lastLoginDate.getUTCMonth(), lastLoginDate.getUTCDate());
-            const diffDays = Math.floor((todayUTC - lastUTC) / (1000 * 60 * 60 * 24));
-
-            if (diffDays === 1) {
-              newStreak += 1; // Perfect continuation
-            } else if (diffDays > 1) {
-              newStreak = 1; // Streak broken, restart
-            }
-
-            // Award 10 points for the new active day
-            newStreakPoints += 10;
-            newTotalPoints += 10;
-          }
-        } else {
-          // Fallback if lastLogin was somehow missing
-          newStreak = 1;
-          newStreakPoints += 10;
-          newTotalPoints += 10;
-        }
-
+        // Existing user: only update lastLogin and repo scope here.
+        // Streak calculation is handled exclusively by checkAndUpdateStreak()
+        // via an atomic runTransaction triggered by the onSnapshot listener.
+        // Duplicating streak logic here caused double streak points on login day.
         await setDoc(userDocRef, {
           lastLogin: today.toISOString(),
-          streak: newStreak,
-          "points.streakPoints": newStreakPoints,
-          "points.totalPoints": newTotalPoints,
           ...(requestRepoScope && { privateRepoSyncEnabled: true })
         }, { merge: true });
       }
@@ -391,7 +356,7 @@ export const AuthProvider = ({ children }) => {
       await updateDoc(userRef, {
         hubCoins: currentCoins - price,
         inventory: [...currentInventory, mascotId],
-        updatedAt: new Date().toISOString() // needed for firestore rules sometimes
+        updatedAt: new Date().toISOString()
       });
       console.log(`Purchased mascot ${mascotId}`);
     } catch (err) {
@@ -436,10 +401,7 @@ export const AuthProvider = ({ children }) => {
       throw new Error("GitHub username can only contain letters, digits, and hyphens, and cannot start or end with a hyphen.");
     }
 
-    // URL-encode the username to prevent injection attacks, though axios should
-    // handle this automatically.
     const encodedUsername = encodeURIComponent(trimmedUsername);
-
     const token = ghAccessToken;
     const headers = token ? { Authorization: `token ${token}` } : {};
 
@@ -495,13 +457,11 @@ export const AuthProvider = ({ children }) => {
         reviews = 0;
       }
 
-      // --- NEW GITHUB LIVE STREAK CALCULATION LOGIC ---
       let githubStreak = 0;
       try {
         const eventsRes = await axios.get(`https://api.github.com/users/${username}/events?per_page=100`, { headers });
         const events = eventsRes.data;
         
-        // Extract unique dates of events (YYYY-MM-DD format)
         const eventDates = new Set(
           events
             .filter(e => e.created_at)
@@ -520,10 +480,8 @@ export const AuthProvider = ({ children }) => {
         if (eventDates.has(todayStr)) {
           // Streak is active today
         } else if (eventDates.has(yesterdayStr)) {
-          // Streak was active yesterday, count from yesterday
           dateToCheck = yesterday;
         } else {
-          // No active streak
           dateToCheck = null;
         }
 
@@ -534,7 +492,7 @@ export const AuthProvider = ({ children }) => {
               githubStreak++;
               dateToCheck.setDate(dateToCheck.getDate() - 1);
             } else {
-              break; // Streak broken
+              break;
             }
           }
         }
@@ -542,7 +500,6 @@ export const AuthProvider = ({ children }) => {
         console.warn("GitHub events retrieval failed for streak:", err);
       }
 
-      // Add points for each day of the active GitHub streak (+10 XP per day)
       const gitRankPoints = (commits * 2) + (prs * 5) + (reviews * 10) + (githubStreak * 10);
 
       return {
@@ -576,7 +533,7 @@ export const AuthProvider = ({ children }) => {
     if (!user || !userData?.githubUsername) return;
 
     if (userData.lastSync) {
-const getTimestamp = (val) => {
+      const getTimestamp = (val) => {
         if (!val) return 0;
         if (val.toMillis) return val.toMillis();
         if (val.seconds) return val.seconds * 1000;
@@ -594,7 +551,6 @@ const getTimestamp = (val) => {
       const ghStats = await fetchGitHubStats(user.uid, userData.githubUsername);
       const userRef = doc(db, "users", user.uid);
 
-      // Phase 1: Retrieve Live Data
       const userDoc = await getDoc(userRef);
       if (!userDoc.exists()) {
         throw new Error("User document does not exist in Firestore!");
@@ -608,8 +564,6 @@ const getTimestamp = (val) => {
       const newGitRankPoints = ghStats.gitRankPoints;
       const newTotalPoints = newGitRankPoints + currentReferralPoints + currentCodingVersePoints + currentStreakPoints;
 
-      // Retained the Atomic Batch Writes (Issue #193)
-      // Phase 2: Issue Atomic Batch Write
       const batch = writeBatch(db);
       
       batch.update(userRef, {
@@ -620,13 +574,12 @@ const getTimestamp = (val) => {
         "githubStats.stars": ghStats.stars,
         "githubStats.followers": ghStats.followers,
         "githubStats.primaryLanguage": ghStats.primaryLanguage,
-        "githubStreak": ghStats.githubStreak, // Syncs live streak to Firestore
+        "githubStreak": ghStats.githubStreak,
         "points.gitRankPoints": newGitRankPoints,
         "points.totalPoints": newTotalPoints,
         "lastSync": serverTimestamp()
       });
 
-      // Execute atomic transaction
       await batch.commit();
 
       console.log("Background GitHub sync completed successfully via atomic batch.");


### PR DESCRIPTION
Fixes #419 

## What's the problem?
On every login, streak points were being awarded twice:

1. Inside `login()` — streak calculated from stale `docSnap.data()` (pre-write snapshot) and written via `setDoc`
2. Inside `checkAndUpdateStreak()` — called by `onSnapshot` which fires immediately after login's `setDoc` write. Since `data` passed to it reflects the **pre-write** `lastLogin`, GUARD 1's `toDateString()` check passes and the `runTransaction` awards streak points a second time

Result: user receives +20 streak points instead of +10 on login day.

## What's the fix?
Removed streak calculation entirely from `login()` for existing users. The `login()` function now only writes `lastLogin` and `privateRepoSyncEnabled`.

Streak logic is delegated exclusively to `checkAndUpdateStreak()` which already has two guards:
- **GUARD 1** (client-side): checks `toDateString()` before entering the transaction
- **GUARD 2** (server-side atomic): re-reads live Firestore data inside `runTransaction` to prevent any race

## Files changed
- `src/context/AuthContext.jsx`

## Testing
- Log in as an existing user on a new day → verify `points.streakPoints` increments by exactly 10
- Log in multiple times on the same day → verify streak does not increment again