### PR TITLE
feat: add Share Profile button utilizing Web Share API and clipboard …

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -19,7 +19,8 @@ import {
   Search,
   Image,
   AlertCircle,
-  Zap
+  Zap,
+  Share2
 } from "lucide-react";
 import { Github, Linkedin, Instagram } from "../components/ui/Icons";
 import { query, collection, where, getCountFromServer, doc, getDoc, writeBatch, updateDoc, getDocs } from "firebase/firestore";
@@ -451,6 +452,49 @@ export const Profile = () => {
     } catch (err) {
       console.error('Share/copy failed', err);
       setToasts((prev) => [...prev, { id: Date.now() + Math.random(), message: 'Failed to copy referral code.', type: 'error' }]);
+    }
+  };
+
+ const handleSharePublicProfile = async () => {
+    // Construct correct public profile URL for the HashRouter
+    const usernameParam = userData?.githubUsername || username;
+    const profileUrl = `${window.location.origin}/#/profile/${usernameParam}`;
+    
+    const shareData = {
+      title: `${userData?.name || 'Developer'}'s RankerHub Profile`,
+      text: 'Check out this ranking and achievements on RankerHub!',
+      url: profileUrl
+    };
+
+    // Prefer native share on mobile/supported devices
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+        setToasts((prev) => [...prev, { id: Date.now() + Math.random(), message: 'Profile shared successfully.', type: 'success' }]);
+        return;
+      } catch (err) {
+        console.debug('Native share canceled or failed', err);
+      }
+    }
+
+    // Clipboard fallback for desktop browsers
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(profileUrl);
+      } else {
+        const ta = document.createElement('textarea');
+        ta.value = profileUrl;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      setToasts((prev) => [...prev, { id: Date.now() + Math.random(), message: 'Profile link copied to clipboard.', type: 'success' }]);
+    } catch (err) {
+      console.error('Share/copy failed', err);
+      setToasts((prev) => [...prev, { id: Date.now() + Math.random(), message: 'Failed to copy profile link.', type: 'error' }]);
     }
   };
 
@@ -1086,7 +1130,7 @@ export const Profile = () => {
 
   return (
     <div className="space-y-8">
-      <SectionHeader
+   <SectionHeader
         title={isOwnProfile ? "Developer Profile" : `${userData?.name || "Developer"}'s Profile`}
         subtitle={isOwnProfile ? "Manage your public links, view achievements, and review earned badges." : `View ${userData?.name || "this developer"}'s achievements and badges.`}
         badge="Verified Account"
@@ -1108,6 +1152,10 @@ export const Profile = () => {
             </GradientButton>
           </>
         )}
+        <GradientButton onClick={handleSharePublicProfile} variant="secondary" className="py-2.5 px-4 text-xs flex items-center gap-1.5">
+          <Share2 className="w-3.5 h-3.5" />
+          Share Profile
+        </GradientButton>
       </SectionHeader>
 
       <Card ref={profileCardRef} className="p-8 relative overflow-hidden flex flex-col md:flex-row items-center gap-8 border-slate-200/50 dark:border-slate-800/50">


### PR DESCRIPTION
# Pull Request 

## Description
This PR implements the requested "Share Profile" functionality. 
Previously, users could only share their referral codes, but had no frictionless way to share their actual public RankerHub profile to showcase their achievements. 

**Changes Made:**
- Added a `handleSharePublicProfile` function to `src/pages/Profile.jsx`.
- Utilized `navigator.share` to trigger the native OS share drawer on mobile devices.
- Implemented a robust `navigator.clipboard` fallback for desktop browsers.
- Integrated the existing `Toast` component for immediate user feedback.
- Placed the "Share Profile" button globally on the `SectionHeader`, allowing users to share their own profiles as well as their friends' profiles.

## Related Issue
Closes #376 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Screenshots / Videos (if applicable)
*(Feel free to drop a screenshot of the new button here!)*

## Testing Done
Tested the implementation on both a desktop environment (verifying clipboard copy and Toast trigger) and simulated mobile views. Verified that the HashRouter URL is correctly parsed and constructed.
- [ ] Command run: `npm run test`
- [x] Command run: `node fix_lint.mjs`
- [x] Command run: `npm run build`
- [x] Visual verification on local dev server (`http://localhost:5173`)

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **GSSoC 2026** and **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the [Contributing Guidelines](https://github.com/indresh404/RankerHub/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://github.com/indresh404/RankerHub/blob/main/docs/CODE_OF_CONDUCT.md).