### PR TITLE
Fix data loss during async commit failure (#392)

### DIFF
--- a/src/utils/firestoreOptimization.js
+++ b/src/utils/firestoreOptimization.js
@@ -201,8 +201,8 @@ export class FirestoreBatchOptimizer {
         }
         await activeBatch.commit();
       } catch (error) {
-        // Re-queue failed operations
-        this.batch = operationsToCommit;
+        // Prepend failed operations so new ops queued during the async commit are preserved
+        this.batch = [...operationsToCommit, ...this.batch];
         throw error;
       }
     }


### PR DESCRIPTION
Fixes #392 
Instead of overwriting the queue, failed operations are now **prepended** to `this.batch`. This ensures:

* **Retry Integrity:** Failed operations are preserved for the next retry.
* **No Data Loss:** Operations added during the async window are maintained.
* **Ordering:** Original operations remain at the front of the queue to preserve execution order.

---
**Changes:**
* Modified `src/utils/firestoreOptimization.js` to merge failed operations with the current queue instead of replacing it.

**Testing:**
* Verified that operations queued during a simulated failed commit are preserved alongside the original batch.