### PR TITLE
fix: move card-builder route above :username param to prevent route shadowing

### DIFF
--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -153,8 +153,8 @@ export const AppRoutes = () => {
           <Route path="/dashboard/friends/followers" element={<Friends />} />
           <Route path="/dashboard/friends/following" element={<Friends />} />
           <Route path="/dashboard/profile" element={<Profile />} />
-          <Route path="/dashboard/profile/:username" element={<Profile />} />
           <Route path="/dashboard/profile/card-builder" element={<CardBuilder />} />
+          <Route path="/dashboard/profile/:username" element={<Profile />} />
           <Route path="/dashboard/settings" element={<SettingsPage />} />
           <Route path="/dashboard/auditor" element={<Auditor />} />
         </Route>


### PR DESCRIPTION
Fixes #445 

## Problem
In React Router v6, routes are matched top-to-bottom. The dynamic route `/:username` was defined before the static `/card-builder` route, causing `/dashboard/profile/card-builder` to render `<Profile />` with `username="card-builder"` instead of the `<CardBuilder />` component.

## Fix
Moved the static `/dashboard/profile/card-builder` route above the dynamic `/:username` route so it is matched first.

## Files changed
- `src/routes/AppRoutes.jsx`