### PR TITLE
fix: enforce onboarding-context guard on referral claims to prevent arbitrary point grants

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -108,6 +108,8 @@ service cloud.firestore {
       // Locks referralPoints to the actual totalEarned value in the referrals index.
       allow update: if isAuthenticated()
         && request.auth.uid != uid
+        // 🛡️ NEW GUARD (Issue #432): Only users actively onboarding can trigger a referral point grant
+        && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.onboardingStatus == "incomplete"
         // Prevent modifying any root-level fields other than points
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['points'])
         // FIX: Sync referralPoints directly with the referrals index document's totalEarned counter
@@ -120,7 +122,6 @@ service cloud.firestore {
         && request.resource.data.points.auditorPoints == resource.data.points.auditorPoints
         && exists(/databases/$(database)/documents/referrals/$(uid))
         && request.auth.uid in get(/databases/$(database)/documents/referrals/$(uid)).data.usedBy;
-    }
 
     match /referrals/{uid} {
       allow read: if isAuthenticated();
@@ -131,6 +132,8 @@ service cloud.firestore {
       // Allow either the owner to write, OR a referred user to atomically append their UID
       allow update: if isOwner(uid) || (
         isAuthenticated()
+        // 🛡️ NEW GUARD (Issue #432): Prevent existing users from arbitrarily claiming codes
+        && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.onboardingStatus == "incomplete"
         && !(request.auth.uid in resource.data.usedBy)
         && request.resource.data.usedBy.size() == resource.data.usedBy.size() + 1
         && request.resource.data.usedBy[resource.data.usedBy.size()] == request.auth.uid


### PR DESCRIPTION
### Description
This PR resolves #432 by closing a major logical vulnerability where any authenticated user could arbitrarily grant referral points to other users bypassing the onboarding flow. 

### Key Changes
* **Onboarding Guard Implementation:** Added strict `get()` validations in both the `/referrals/{uid}` update rule and RULE 4 of `/users/{uid}`.
* **Context Verification:** The rules now explicitly verify that `get(/databases/$(database)/documents/users/$(request.auth.uid)).data.onboardingStatus == "incomplete"`. If the claiming user has already completed onboarding, the Firestore write is securely rejected.

Fixes #432