### PR TITLE
feat: implement SWR in-memory navigation cache hook to prevent redundant firestore listener mounts

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -108,6 +108,8 @@ service cloud.firestore {
       // Locks referralPoints to the actual totalEarned value in the referrals index.
       allow update: if isAuthenticated()
         && request.auth.uid != uid
+        // 🛡️ NEW GUARD (Issue #432): Only users actively onboarding can trigger a referral point grant
+        && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.onboardingStatus == "incomplete"
         // Prevent modifying any root-level fields other than points
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['points'])
         // FIX: Sync referralPoints directly with the referrals index document's totalEarned counter
@@ -120,7 +122,6 @@ service cloud.firestore {
         && request.resource.data.points.auditorPoints == resource.data.points.auditorPoints
         && exists(/databases/$(database)/documents/referrals/$(uid))
         && request.auth.uid in get(/databases/$(database)/documents/referrals/$(uid)).data.usedBy;
-    }
 
     match /referrals/{uid} {
       allow read: if isAuthenticated();
@@ -131,6 +132,8 @@ service cloud.firestore {
       // Allow either the owner to write, OR a referred user to atomically append their UID
       allow update: if isOwner(uid) || (
         isAuthenticated()
+        // 🛡️ NEW GUARD (Issue #432): Prevent existing users from arbitrarily claiming codes
+        && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.onboardingStatus == "incomplete"
         && !(request.auth.uid in resource.data.usedBy)
         && request.resource.data.usedBy.size() == resource.data.usedBy.size() + 1
         && request.resource.data.usedBy[resource.data.usedBy.size()] == request.auth.uid

--- a/src/components/ui/ErrorBoundary.jsx
+++ b/src/components/ui/ErrorBoundary.jsx
@@ -1,9 +1,10 @@
 import React, { Component } from "react";
+import { motion } from "framer-motion"; 
 
 export class ErrorBoundary extends Component {
   constructor(props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false, error: null, errorInfo: null };
   }
 
   static getDerivedStateFromError(error) {
@@ -12,13 +13,30 @@ export class ErrorBoundary extends Component {
 
   componentDidCatch(error, errorInfo) {
     console.error("ErrorBoundary caught an error:", error, errorInfo);
+    this.setState({ errorInfo });
   }
+
+  // ADDED: Graceful recovery method (No full page reload)
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  };
 
   render() {
     if (this.state.hasError) {
+      // ADDED: Dynamic context-specific message
+      const customMessage = this.props.fallbackMessage || "The application encountered an unexpected error. Don't worry, your data is safe.";
+
       return (
-        <div className="min-h-screen flex flex-col items-center justify-center bg-slate-50 dark:bg-slate-950 p-6 text-slate-800 dark:text-slate-100 transition-colors duration-300">
-          <div className="max-w-md w-full backdrop-blur-xl bg-white/70 dark:bg-slate-900/70 border border-slate-200/50 dark:border-slate-800/50 shadow-2xl rounded-2xl p-8 text-center flex flex-col items-center">
+        // Changed min-h-screen to min-h-[60vh] so it fits perfectly inside dashboard layouts too
+        <div className="w-full h-full min-h-[60vh] flex flex-col items-center justify-center p-6 text-slate-800 dark:text-slate-100 transition-colors duration-300">
+          
+          {/* ADDED: Framer motion wrapper for entry animation */}
+          <motion.div 
+            initial={{ opacity: 0, y: 20, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ duration: 0.4, ease: "easeOut" }}
+            className="max-w-md w-full backdrop-blur-xl bg-white/70 dark:bg-slate-900/70 border border-slate-200/50 dark:border-slate-800/50 shadow-2xl rounded-2xl p-8 text-center flex flex-col items-center"
+          >
             {/* Premium CSS-Animated SVG warning graphic */}
             <div className="relative w-40 h-40 mb-6 flex items-center justify-center">
               {/* Glowing backdrop rings */}
@@ -33,19 +51,31 @@ export class ErrorBoundary extends Component {
                 </svg>
               </div>
             </div>
+            
             <h1 className="text-2xl font-bold mb-2 text-transparent bg-clip-text bg-gradient-to-r from-violet-500 to-blue-500">
               Something went wrong.
             </h1>
+            
             <p className="text-sm text-slate-500 dark:text-slate-400 mb-6 font-medium">
-              The application encountered an unexpected error. Don't worry, your data is safe.
+              {customMessage}
             </p>
+
+            {/* ADDED: Hidden technical details for developers (only shows in localhost/dev mode) */}
+            {process.env.NODE_ENV === 'development' && this.state.error && (
+              <div className="w-full mb-6 p-3 bg-slate-50 dark:bg-slate-950 rounded-lg text-left overflow-hidden">
+                <p className="text-[10px] font-mono text-red-500 break-words">
+                  {this.state.error.toString()}
+                </p>
+              </div>
+            )}
+
             <button
-              onClick={() => window.location.reload()}
-              className="px-6 py-2.5 rounded-xl bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white font-semibold shadow-lg hover:shadow-indigo-500/20 active:scale-95 transition-all duration-200 cursor-pointer"
+              onClick={this.handleRetry}
+              className="px-6 py-2.5 w-full rounded-xl bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white font-semibold shadow-lg hover:shadow-indigo-500/20 active:scale-95 transition-all duration-200 cursor-pointer"
             >
-              Refresh Page
+              Try Again
             </button>
-          </div>
+          </motion.div>
         </div>
       );
     }

--- a/src/context/FirestoreCacheContext.jsx
+++ b/src/context/FirestoreCacheContext.jsx
@@ -1,0 +1,76 @@
+import React, { createContext, useContext, useRef, useState, useEffect } from 'react';
+
+const CacheContext = createContext();
+
+export const FirestoreCacheProvider = ({ children }) => {
+  // Map store to hold cached data and timestamps
+  const cache = useRef(new Map());
+
+  return (
+    <CacheContext.Provider value={cache}>
+      {children}
+    </CacheContext.Provider>
+  );
+};
+
+export const useFirestoreCache = (cacheKey, fetcherFn, ttl = 60000) => {
+  const cache = useContext(CacheContext);
+  if (!cache) {
+    throw new Error("useFirestoreCache must be used within a FirestoreCacheProvider");
+  }
+
+  // Initialize with cached data if it exists
+  const [data, setData] = useState(() => {
+    const cached = cache.current.get(cacheKey);
+    return cached ? cached.data : null;
+  });
+  
+  // Only show loading spinner if we have absolutely no data
+  const [loading, setLoading] = useState(!data);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const executeFetch = async () => {
+      const cached = cache.current.get(cacheKey);
+      const now = Date.now();
+      
+      // If data exists and is within TTL, skip fetching entirely
+      if (cached && (now - cached.ts < ttl)) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const freshData = await fetcherFn();
+        if (!isMounted) return;
+
+        // Deep Comparison Check (prevents unnecessary re-renders)
+        const isDataChanged = !cached || JSON.stringify(cached.data) !== JSON.stringify(freshData);
+
+        if (isDataChanged) {
+          setData(freshData);
+          cache.current.set(cacheKey, { data: freshData, ts: Date.now() });
+        }
+      } catch (err) {
+        if (isMounted) setError(err);
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    executeFetch();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [cacheKey]); // Important: fetcherFn is omitted to prevent infinite loops
+
+  // Function to manually invalidate cache (e.g., after a mutation)
+  const invalidateCache = () => {
+    cache.current.delete(cacheKey);
+  };
+
+  return { data, loading, error, invalidateCache };
+};

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { Search, Filter, Star, Trophy, RefreshCw, GitCommit, Calendar, BookOpen, AlertCircle, CheckCircle2, Users, Medal } from "lucide-react";
-import { collection, query, doc, where, orderBy, limit, startAfter, onSnapshot, getDocs, runTransaction, serverTimestamp } from "firebase/firestore";
+import { collection, query, doc, where, orderBy, limit, startAfter, getDocs, runTransaction, serverTimestamp } from "firebase/firestore";
 import { useSearchParams } from "react-router-dom";
 import { TableVirtuoso } from "react-virtuoso"; 
 import { db } from "../lib/firebase";
 import { useAuth } from "../context/AuthContext";
+import { useFirestoreCache } from "../context/FirestoreCacheContext"; 
 import Card from "../components/ui/Card";
 import SectionHeader from "../components/ui/SectionHeader";
 import GradientButton from "../components/ui/GradientButton";
@@ -13,16 +14,10 @@ import axios from "axios";
 export const GitRank = () => {
   const { user, userData, fetchGitHubStats, login } = useAuth();
 
-  // ============================================================
-  // ISSUE #194: URL Parameter Sync for State Persistence
-  // ISSUE #362: Server-Side College Filter Integration
-  // ============================================================
   const [searchParams, setSearchParams] = useSearchParams();
   const searchTerm = searchParams.get("search") || "";
   const selectedLanguage = searchParams.get("lang") || "All";
-  const selectedCollege = searchParams.get("college") || "All"; // NEW: Server-Side College State
-
-  // Active Tab for Referral Leaderboard (Issue #310) - Now synced with URL
+  const selectedCollege = searchParams.get("college") || "All"; 
   const activeTab = searchParams.get("tab") || "gitrank";
 
   const handleSearchChange = (e) => {
@@ -59,9 +54,8 @@ export const GitRank = () => {
   const [hasMore, setHasMore] = useState(true); 
   const [loadingMore, setLoadingMore] = useState(false); 
 
-  // Real-time leaderboard state
+  // Local Leaderboard state
   const [usersList, setUsersList] = useState([]);
-  const [loadingUsers, setLoadingUsers] = useState(true);
 
   // Syncing state
   const [isSyncing, setIsSyncing] = useState(false);
@@ -77,12 +71,10 @@ export const GitRank = () => {
 
   const languages = ["All", "TypeScript", "Rust", "Go", "Python", "Kotlin", "Ruby", "JavaScript"];
 
-  // 1. Real-time Leaderboard Listener (Server-Side Filtered)
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLoadingUsers(true);
+  // In-Memory Navigation Cache Hook Integration
+  const cacheKey = `gitrank_${activeTab}_${selectedLanguage}_${selectedCollege}`;
 
-    // Build the query dynamically based on Active Tab and Tie-Breakers
+  const fetchLeaderboard = async () => {
     const constraints = [
       where("onboardingStatus", "==", "complete"),
     ];
@@ -96,12 +88,10 @@ export const GitRank = () => {
     
     constraints.push(orderBy("githubUsername", "asc"));
 
-    // DB level language filter
     if (selectedLanguage !== "All") {
       constraints.push(where("githubStats.primaryLanguage", "==", selectedLanguage));
     }
 
-    // DB level college filter (Resolves Issue #362)
     if (selectedCollege !== "All" && selectedCollege.trim() !== "") {
       constraints.push(where("college", "==", selectedCollege));
     }
@@ -109,33 +99,37 @@ export const GitRank = () => {
     constraints.push(limit(50));
 
     const q = query(collection(db, "users"), ...constraints);
+    const snapshot = await getDocs(q); // Switched from onSnapshot to getDocs to save reads
 
-    const unsubscribe = onSnapshot(
-      q,
-      (snapshot) => {
-        const users = [];
-        snapshot.forEach((doc) => {
-          users.push(doc.data());
-        });
+    const users = [];
+    snapshot.forEach((doc) => {
+      users.push(doc.data());
+    });
 
-        const ranked = users.map((u, i) => ({
-          ...u,
-          rank: i + 1
-        }));
+    const ranked = users.map((u, i) => ({
+      ...u,
+      rank: i + 1
+    }));
 
-        setUsersList(ranked);
-        setLastVisible(snapshot.docs[snapshot.docs.length - 1]);
-        setHasMore(snapshot.docs.length === 50); 
-        setLoadingUsers(false);
-      },
-      (error) => {
-        console.error("Leaderboard subscription error:", error);
-        setLoadingUsers(false);
-      }
-    );
+    // Return the bundle so cache hook holds both data and pagination cursors
+    return {
+      users: ranked,
+      lastVisible: snapshot.docs[snapshot.docs.length - 1] || null,
+      hasMore: snapshot.docs.length === 50
+    };
+  };
 
-    return () => unsubscribe();
-  }, [selectedLanguage, activeTab, selectedCollege]); 
+  // TTL set to 60000ms (1 minute). Modifying filters changes the key instantly.
+  const { data: cachedData, loading: loadingUsers, invalidateCache } = useFirestoreCache(cacheKey, fetchLeaderboard, 60000);
+
+  // Sync the cached data payload into local component state
+  useEffect(() => {
+    if (cachedData) {
+      setUsersList(cachedData.users);
+      setLastVisible(cachedData.lastVisible);
+      setHasMore(cachedData.hasMore);
+    }
+  }, [cachedData]);
 
   // Pagination Function (Fetch next 50)
   const loadMoreUsers = async () => {
@@ -200,7 +194,6 @@ export const GitRank = () => {
   // 2. Fetch GitHub Events/Repos for Charts (Authenticated Only)
   useEffect(() => {
     if (!userData?.githubUsername) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setLoadingCharts(false);
       return;
     }
@@ -343,6 +336,9 @@ export const GitRank = () => {
         });
       });
 
+      // Clear the cache manually because our own points just updated!
+      invalidateCache();
+      
       setSyncSuccess("GitHub statistics updated in real time!");
       setTimeout(() => setSyncSuccess(""), 4000);
     } catch (err) {
@@ -390,7 +386,6 @@ export const GitRank = () => {
     return `${mins}m ${secs}s`;
   };
 
-// Filter leaderboard lists (Only Search is client side now)
   const filteredData = useMemo(() => {
     return usersList.filter((u) => {
       const name = u.name || "";
@@ -433,7 +428,7 @@ export const GitRank = () => {
     return weeks;
   }, [events]);
 
-// Chart Parsing 2: Languages Frequency
+  // Chart Parsing 2: Languages Frequency
   const languageChartData = useMemo(() => {
     if (!repos.length) return [];
     

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,35 +1,38 @@
-import React from "react";
+import React, { Suspense } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import PublicLayout from "../layouts/PublicLayout";
 import DashboardLayout from "../layouts/DashboardLayout";
-import Home from "../pages/Home";
-import Dashboard from "../pages/Dashboard";
-import GitRank from "../pages/GitRank";
-import RankHer from "../pages/RankHer";
-import CodingVerse from "../pages/CodingVerse";
-import CodingOwl from "../pages/CodingOwl";
-import Matchmaker from "../pages/Matchmaker";
-import Profile from "../pages/Profile";
-import Friends from "../pages/Friends";
-import Login from "../pages/Login";
-import Onboarding from "../pages/Onboarding";
-import NotFound from "../pages/NotFound";
-import Achievements from "../pages/Achievements";
-import About from "../pages/About";
-import Terms from "../pages/Terms";    
-import Privacy from "../pages/Privacy";
 import ComingSoonCard from "../components/ui/ComingSoonCard";
 import GlobalModals from "../components/ui/GlobalModals";
 import { Settings as SettingsIcon } from "lucide-react";
-import Auditor from "../pages/Auditor";
+
+// Lazy Loaded Pages to reduce initial JS bundle
+const Home = React.lazy(() => import("../pages/Home"));
+const Dashboard = React.lazy(() => import("../pages/Dashboard"));
+const GitRank = React.lazy(() => import("../pages/GitRank"));
+const RankHer = React.lazy(() => import("../pages/RankHer"));
+const CodingVerse = React.lazy(() => import("../pages/CodingVerse"));
+const CodingOwl = React.lazy(() => import("../pages/CodingOwl"));
+const Matchmaker = React.lazy(() => import("../pages/Matchmaker"));
+const Profile = React.lazy(() => import("../pages/Profile"));
+const Friends = React.lazy(() => import("../pages/Friends"));
+const Login = React.lazy(() => import("../pages/Login"));
+const Onboarding = React.lazy(() => import("../pages/Onboarding"));
+const NotFound = React.lazy(() => import("../pages/NotFound"));
+const Achievements = React.lazy(() => import("../pages/Achievements"));
+const About = React.lazy(() => import("../pages/About"));
+const Terms = React.lazy(() => import("../pages/Terms"));
+const Privacy = React.lazy(() => import("../pages/Privacy"));
+const Auditor = React.lazy(() => import("../pages/Auditor"));
+const CardBuilder = React.lazy(() => import("../pages/CardBuilder"));
 
 // Inline loading indicator
 const LoadingScreen = ({ message }) => (
   <div className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-[#090D1A]">
     <div className="flex flex-col items-center space-y-4">
       <div className="w-10 h-10 border-4 border-violet-500 border-t-transparent rounded-full animate-spin" />
-      <span className="text-sm text-slate-400 font-bold tracking-widest uppercase">{message || "Syncing Session..."}</span>
+      <span className="text-sm text-slate-400 font-bold tracking-widest uppercase">{message || "Loading..."}</span>
     </div>
   </div>
 );
@@ -92,8 +95,6 @@ const GuestRoute = ({ children }) => {
   return children;
 };
 
-import CardBuilder from "../pages/CardBuilder";
-
 // An inline settings page to keep route integrated
 const SettingsPage = () => (
   <div className="space-y-6">
@@ -116,52 +117,54 @@ const SettingsPage = () => (
 export const AppRoutes = () => {
   return (
     <>
-      <Routes>
-        {/* Public Site Layout & Pages */}
-        <Route element={<PublicLayout />}>
-          <Route path="/" element={<Home />} />
-          <Route path="/gitrank" element={<GitRank />} />
-          <Route path="/rankher" element={<RankHer />} />
-          <Route path="/codingverse" element={<CodingVerse />} />
-          <Route path="/codingowl" element={<CodingOwl />} />
-        </Route>
+      <Suspense fallback={<LoadingScreen message="Loading Page..." />}>
+        <Routes>
+          {/* Public Site Layout & Pages */}
+          <Route element={<PublicLayout />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/gitrank" element={<GitRank />} />
+            <Route path="/rankher" element={<RankHer />} />
+            <Route path="/codingverse" element={<CodingVerse />} />
+            <Route path="/codingowl" element={<CodingOwl />} />
+          </Route>
 
-        {/* Standalone About Us page */}
-        <Route path="/about" element={<About />} />
+          {/* Standalone About Us page */}
+          <Route path="/about" element={<About />} />
 
-        {/* Standalone Legal pages */}
-        <Route path="/terms" element={<Terms />} />
-        <Route path="/privacy" element={<Privacy />} />
+          {/* Standalone Legal pages */}
+          <Route path="/terms" element={<Terms />} />
+          <Route path="/privacy" element={<Privacy />} />
 
-        {/* Public Login page (standalone) - guarded from logged in users */}
-        <Route path="/login" element={<GuestRoute><Login /></GuestRoute>} />
-        
-        {/* Onboarding page (standalone) - guarded so only incomplete profiles see it */}
-        <Route path="/onboarding" element={<OnboardingRoute><Onboarding /></OnboardingRoute>} />
-        
-        {/* Layout dashboard sub-pages - locked to authenticated & fully onboarded users */}
-        <Route element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/dashboard/gitrank" element={<GitRank />} />
-          <Route path="/dashboard/rankher" element={<RankHer />} />
-          <Route path="/dashboard/achievements" element={<Achievements />} />
-          <Route path="/dashboard/codingverse" element={<CodingVerse />} />
-          <Route path="/dashboard/codingowl" element={<CodingOwl />} />
-          <Route path="/dashboard/matchmaker" element={<Matchmaker />} />
-          <Route path="/dashboard/friends" element={<Friends />} />
-          <Route path="/dashboard/friends/leaderboard" element={<Friends />} />
-          <Route path="/dashboard/friends/followers" element={<Friends />} />
-          <Route path="/dashboard/friends/following" element={<Friends />} />
-          <Route path="/dashboard/profile" element={<Profile />} />
-          <Route path="/dashboard/profile/card-builder" element={<CardBuilder />} />
-          <Route path="/dashboard/profile/:username" element={<Profile />} />
-          <Route path="/dashboard/settings" element={<SettingsPage />} />
-          <Route path="/dashboard/auditor" element={<Auditor />} />
-        </Route>
+          {/* Public Login page (standalone) - guarded from logged in users */}
+          <Route path="/login" element={<GuestRoute><Login /></GuestRoute>} />
+          
+          {/* Onboarding page (standalone) - guarded so only incomplete profiles see it */}
+          <Route path="/onboarding" element={<OnboardingRoute><Onboarding /></OnboardingRoute>} />
+          
+          {/* Layout dashboard sub-pages - locked to authenticated & fully onboarded users */}
+          <Route element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/dashboard/gitrank" element={<GitRank />} />
+            <Route path="/dashboard/rankher" element={<RankHer />} />
+            <Route path="/dashboard/achievements" element={<Achievements />} />
+            <Route path="/dashboard/codingverse" element={<CodingVerse />} />
+            <Route path="/dashboard/codingowl" element={<CodingOwl />} />
+            <Route path="/dashboard/matchmaker" element={<Matchmaker />} />
+            <Route path="/dashboard/friends" element={<Friends />} />
+            <Route path="/dashboard/friends/leaderboard" element={<Friends />} />
+            <Route path="/dashboard/friends/followers" element={<Friends />} />
+            <Route path="/dashboard/friends/following" element={<Friends />} />
+            <Route path="/dashboard/profile" element={<Profile />} />
+            <Route path="/dashboard/profile/card-builder" element={<CardBuilder />} />
+            <Route path="/dashboard/profile/:username" element={<Profile />} />
+            <Route path="/dashboard/settings" element={<SettingsPage />} />
+            <Route path="/dashboard/auditor" element={<Auditor />} />
+          </Route>
 
-        {/* 404 Catch All */}
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+          {/* 404 Catch All */}
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Suspense>
       <GlobalModals />
     </>
   );

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -6,6 +6,7 @@ import DashboardLayout from "../layouts/DashboardLayout";
 import ComingSoonCard from "../components/ui/ComingSoonCard";
 import GlobalModals from "../components/ui/GlobalModals";
 import { Settings as SettingsIcon } from "lucide-react";
+import ErrorBoundary from "../components/ui/ErrorBoundary"; 
 
 // Lazy Loaded Pages to reduce initial JS bundle
 const Home = React.lazy(() => import("../pages/Home"));
@@ -68,8 +69,6 @@ const OnboardingRoute = ({ children }) => {
     return <Navigate to="/login" replace />;
   }
 
-  // Strict guard: if the user's data explicitly says they are complete, OR if isOnboarding is false, redirect.
-  // We only allow access if they are explicitly incomplete.
   if (userData?.onboardingStatus === "complete" || !isOnboarding || (userData && userData.onboardingStatus !== "incomplete")) {
     return <Navigate to="/dashboard" replace />;
   }
@@ -82,7 +81,7 @@ const GuestRoute = ({ children }) => {
   const { user, loading, isOnboarding } = useAuth();
 
   if (loading) {
-    return null; // Don't redirect prematurely while state is resolving
+    return null; 
   }
 
   if (user) {
@@ -95,7 +94,6 @@ const GuestRoute = ({ children }) => {
   return children;
 };
 
-// An inline settings page to keep route integrated
 const SettingsPage = () => (
   <div className="space-y-6">
     <ComingSoonCard
@@ -114,6 +112,13 @@ const SettingsPage = () => (
   </div>
 );
 
+// Helper wrapper to easily wrap lazy components with ErrorBoundary
+const withErrorBoundary = (Component, componentName, fallbackMessage) => (
+  <ErrorBoundary componentName={componentName} fallbackMessage={fallbackMessage}>
+    <Component />
+  </ErrorBoundary>
+);
+
 export const AppRoutes = () => {
   return (
     <>
@@ -121,44 +126,44 @@ export const AppRoutes = () => {
         <Routes>
           {/* Public Site Layout & Pages */}
           <Route element={<PublicLayout />}>
-            <Route path="/" element={<Home />} />
-            <Route path="/gitrank" element={<GitRank />} />
-            <Route path="/rankher" element={<RankHer />} />
-            <Route path="/codingverse" element={<CodingVerse />} />
-            <Route path="/codingowl" element={<CodingOwl />} />
+            <Route path="/" element={withErrorBoundary(Home, "Home", "Failed to load the homepage. Please try refreshing.")} />
+            <Route path="/gitrank" element={withErrorBoundary(GitRank, "GitRank", "GitRank couldn't load right now. Try refreshing, or sync your GitHub stats.")} />
+            <Route path="/rankher" element={withErrorBoundary(RankHer, "RankHer", "Failed to load RankHer leaderboard. Please check your connection.")} />
+            <Route path="/codingverse" element={withErrorBoundary(CodingVerse, "CodingVerse", "CodingVerse arenas failed to load. Please try again.")} />
+            <Route path="/codingowl" element={withErrorBoundary(CodingOwl, "CodingOwl", "Failed to load your habit tracker. Please try again.")} />
           </Route>
 
           {/* Standalone About Us page */}
-          <Route path="/about" element={<About />} />
+          <Route path="/about" element={withErrorBoundary(About, "About", "Failed to load the About page.")} />
 
           {/* Standalone Legal pages */}
-          <Route path="/terms" element={<Terms />} />
-          <Route path="/privacy" element={<Privacy />} />
+          <Route path="/terms" element={withErrorBoundary(Terms, "Terms", "Failed to load Terms of Service.")} />
+          <Route path="/privacy" element={withErrorBoundary(Privacy, "Privacy", "Failed to load Privacy Policy.")} />
 
-          {/* Public Login page (standalone) - guarded from logged in users */}
-          <Route path="/login" element={<GuestRoute><Login /></GuestRoute>} />
+          {/* Public Login page */}
+          <Route path="/login" element={<GuestRoute>{withErrorBoundary(Login, "Login", "Failed to initialize the login portal.")}</GuestRoute>} />
           
-          {/* Onboarding page (standalone) - guarded so only incomplete profiles see it */}
-          <Route path="/onboarding" element={<OnboardingRoute><Onboarding /></OnboardingRoute>} />
+          {/* Onboarding page */}
+          <Route path="/onboarding" element={<OnboardingRoute>{withErrorBoundary(Onboarding, "Onboarding", "Failed to load the onboarding flow.")}</OnboardingRoute>} />
           
-          {/* Layout dashboard sub-pages - locked to authenticated & fully onboarded users */}
+          {/* Layout dashboard sub-pages */}
           <Route element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/dashboard/gitrank" element={<GitRank />} />
-            <Route path="/dashboard/rankher" element={<RankHer />} />
-            <Route path="/dashboard/achievements" element={<Achievements />} />
-            <Route path="/dashboard/codingverse" element={<CodingVerse />} />
-            <Route path="/dashboard/codingowl" element={<CodingOwl />} />
-            <Route path="/dashboard/matchmaker" element={<Matchmaker />} />
-            <Route path="/dashboard/friends" element={<Friends />} />
-            <Route path="/dashboard/friends/leaderboard" element={<Friends />} />
-            <Route path="/dashboard/friends/followers" element={<Friends />} />
-            <Route path="/dashboard/friends/following" element={<Friends />} />
-            <Route path="/dashboard/profile" element={<Profile />} />
-            <Route path="/dashboard/profile/card-builder" element={<CardBuilder />} />
-            <Route path="/dashboard/profile/:username" element={<Profile />} />
+            <Route path="/dashboard" element={withErrorBoundary(Dashboard, "Dashboard", "Your dashboard failed to load. Try refreshing the page.")} />
+            <Route path="/dashboard/gitrank" element={withErrorBoundary(GitRank, "GitRank", "GitRank couldn't load right now. Try refreshing, or sync your GitHub stats.")} />
+            <Route path="/dashboard/rankher" element={withErrorBoundary(RankHer, "RankHer", "Failed to load RankHer data.")} />
+            <Route path="/dashboard/achievements" element={withErrorBoundary(Achievements, "Achievements", "Failed to load your badges and trophies.")} />
+            <Route path="/dashboard/codingverse" element={withErrorBoundary(CodingVerse, "CodingVerse", "CodingVerse challenges failed to load.")} />
+            <Route path="/dashboard/codingowl" element={withErrorBoundary(CodingOwl, "CodingOwl", "Failed to load CodingOwl streaks.")} />
+            <Route path="/dashboard/matchmaker" element={withErrorBoundary(Matchmaker, "Matchmaker", "Failed to find developer matches.")} />
+            <Route path="/dashboard/friends" element={withErrorBoundary(Friends, "Friends", "Failed to load your social network.")} />
+            <Route path="/dashboard/friends/leaderboard" element={withErrorBoundary(Friends, "Friends Leaderboard", "Failed to load friends leaderboard.")} />
+            <Route path="/dashboard/friends/followers" element={withErrorBoundary(Friends, "Followers", "Failed to load followers list.")} />
+            <Route path="/dashboard/friends/following" element={withErrorBoundary(Friends, "Following", "Failed to load following list.")} />
+            <Route path="/dashboard/profile" element={withErrorBoundary(Profile, "Profile", "Your profile data failed to load.")} />
+            <Route path="/dashboard/profile/card-builder" element={withErrorBoundary(CardBuilder, "Card Builder", "Failed to initialize the dev card builder.")} />
+            <Route path="/dashboard/profile/:username" element={withErrorBoundary(Profile, "User Profile", "This developer's profile failed to load.")} />
             <Route path="/dashboard/settings" element={<SettingsPage />} />
-            <Route path="/dashboard/auditor" element={<Auditor />} />
+            <Route path="/dashboard/auditor" element={withErrorBoundary(Auditor, "Auditor", "Security audit logs failed to load.")} />
           </Route>
 
           {/* 404 Catch All */}

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -7,6 +7,7 @@ import ComingSoonCard from "../components/ui/ComingSoonCard";
 import GlobalModals from "../components/ui/GlobalModals";
 import { Settings as SettingsIcon } from "lucide-react";
 import ErrorBoundary from "../components/ui/ErrorBoundary"; 
+import { FirestoreCacheProvider } from "../context/FirestoreCacheContext";
 
 // Lazy Loaded Pages to reduce initial JS bundle
 const Home = React.lazy(() => import("../pages/Home"));
@@ -122,54 +123,56 @@ const withErrorBoundary = (Component, componentName, fallbackMessage) => (
 export const AppRoutes = () => {
   return (
     <>
-      <Suspense fallback={<LoadingScreen message="Loading Page..." />}>
-        <Routes>
-          {/* Public Site Layout & Pages */}
-          <Route element={<PublicLayout />}>
-            <Route path="/" element={withErrorBoundary(Home, "Home", "Failed to load the homepage. Please try refreshing.")} />
-            <Route path="/gitrank" element={withErrorBoundary(GitRank, "GitRank", "GitRank couldn't load right now. Try refreshing, or sync your GitHub stats.")} />
-            <Route path="/rankher" element={withErrorBoundary(RankHer, "RankHer", "Failed to load RankHer leaderboard. Please check your connection.")} />
-            <Route path="/codingverse" element={withErrorBoundary(CodingVerse, "CodingVerse", "CodingVerse arenas failed to load. Please try again.")} />
-            <Route path="/codingowl" element={withErrorBoundary(CodingOwl, "CodingOwl", "Failed to load your habit tracker. Please try again.")} />
-          </Route>
+      <FirestoreCacheProvider>
+        <Suspense fallback={<LoadingScreen message="Loading Page..." />}>
+          <Routes>
+            {/* Public Site Layout & Pages */}
+            <Route element={<PublicLayout />}>
+              <Route path="/" element={withErrorBoundary(Home, "Home", "Failed to load the homepage. Please try refreshing.")} />
+              <Route path="/gitrank" element={withErrorBoundary(GitRank, "GitRank", "GitRank couldn't load right now. Try refreshing, or sync your GitHub stats.")} />
+              <Route path="/rankher" element={withErrorBoundary(RankHer, "RankHer", "Failed to load RankHer leaderboard. Please check your connection.")} />
+              <Route path="/codingverse" element={withErrorBoundary(CodingVerse, "CodingVerse", "CodingVerse arenas failed to load. Please try again.")} />
+              <Route path="/codingowl" element={withErrorBoundary(CodingOwl, "CodingOwl", "Failed to load your habit tracker. Please try again.")} />
+            </Route>
 
-          {/* Standalone About Us page */}
-          <Route path="/about" element={withErrorBoundary(About, "About", "Failed to load the About page.")} />
+            {/* Standalone About Us page */}
+            <Route path="/about" element={withErrorBoundary(About, "About", "Failed to load the About page.")} />
 
-          {/* Standalone Legal pages */}
-          <Route path="/terms" element={withErrorBoundary(Terms, "Terms", "Failed to load Terms of Service.")} />
-          <Route path="/privacy" element={withErrorBoundary(Privacy, "Privacy", "Failed to load Privacy Policy.")} />
+            {/* Standalone Legal pages */}
+            <Route path="/terms" element={withErrorBoundary(Terms, "Terms", "Failed to load Terms of Service.")} />
+            <Route path="/privacy" element={withErrorBoundary(Privacy, "Privacy", "Failed to load Privacy Policy.")} />
 
-          {/* Public Login page */}
-          <Route path="/login" element={<GuestRoute>{withErrorBoundary(Login, "Login", "Failed to initialize the login portal.")}</GuestRoute>} />
-          
-          {/* Onboarding page */}
-          <Route path="/onboarding" element={<OnboardingRoute>{withErrorBoundary(Onboarding, "Onboarding", "Failed to load the onboarding flow.")}</OnboardingRoute>} />
-          
-          {/* Layout dashboard sub-pages */}
-          <Route element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>
-            <Route path="/dashboard" element={withErrorBoundary(Dashboard, "Dashboard", "Your dashboard failed to load. Try refreshing the page.")} />
-            <Route path="/dashboard/gitrank" element={withErrorBoundary(GitRank, "GitRank", "GitRank couldn't load right now. Try refreshing, or sync your GitHub stats.")} />
-            <Route path="/dashboard/rankher" element={withErrorBoundary(RankHer, "RankHer", "Failed to load RankHer data.")} />
-            <Route path="/dashboard/achievements" element={withErrorBoundary(Achievements, "Achievements", "Failed to load your badges and trophies.")} />
-            <Route path="/dashboard/codingverse" element={withErrorBoundary(CodingVerse, "CodingVerse", "CodingVerse challenges failed to load.")} />
-            <Route path="/dashboard/codingowl" element={withErrorBoundary(CodingOwl, "CodingOwl", "Failed to load CodingOwl streaks.")} />
-            <Route path="/dashboard/matchmaker" element={withErrorBoundary(Matchmaker, "Matchmaker", "Failed to find developer matches.")} />
-            <Route path="/dashboard/friends" element={withErrorBoundary(Friends, "Friends", "Failed to load your social network.")} />
-            <Route path="/dashboard/friends/leaderboard" element={withErrorBoundary(Friends, "Friends Leaderboard", "Failed to load friends leaderboard.")} />
-            <Route path="/dashboard/friends/followers" element={withErrorBoundary(Friends, "Followers", "Failed to load followers list.")} />
-            <Route path="/dashboard/friends/following" element={withErrorBoundary(Friends, "Following", "Failed to load following list.")} />
-            <Route path="/dashboard/profile" element={withErrorBoundary(Profile, "Profile", "Your profile data failed to load.")} />
-            <Route path="/dashboard/profile/card-builder" element={withErrorBoundary(CardBuilder, "Card Builder", "Failed to initialize the dev card builder.")} />
-            <Route path="/dashboard/profile/:username" element={withErrorBoundary(Profile, "User Profile", "This developer's profile failed to load.")} />
-            <Route path="/dashboard/settings" element={<SettingsPage />} />
-            <Route path="/dashboard/auditor" element={withErrorBoundary(Auditor, "Auditor", "Security audit logs failed to load.")} />
-          </Route>
+            {/* Public Login page */}
+            <Route path="/login" element={<GuestRoute>{withErrorBoundary(Login, "Login", "Failed to initialize the login portal.")}</GuestRoute>} />
+            
+            {/* Onboarding page */}
+            <Route path="/onboarding" element={<OnboardingRoute>{withErrorBoundary(Onboarding, "Onboarding", "Failed to load the onboarding flow.")}</OnboardingRoute>} />
+            
+            {/* Layout dashboard sub-pages */}
+            <Route element={<ProtectedRoute><DashboardLayout /></ProtectedRoute>}>
+              <Route path="/dashboard" element={withErrorBoundary(Dashboard, "Dashboard", "Your dashboard failed to load. Try refreshing the page.")} />
+              <Route path="/dashboard/gitrank" element={withErrorBoundary(GitRank, "GitRank", "GitRank couldn't load right now. Try refreshing, or sync your GitHub stats.")} />
+              <Route path="/dashboard/rankher" element={withErrorBoundary(RankHer, "RankHer", "Failed to load RankHer data.")} />
+              <Route path="/dashboard/achievements" element={withErrorBoundary(Achievements, "Achievements", "Failed to load your badges and trophies.")} />
+              <Route path="/dashboard/codingverse" element={withErrorBoundary(CodingVerse, "CodingVerse", "CodingVerse challenges failed to load.")} />
+              <Route path="/dashboard/codingowl" element={withErrorBoundary(CodingOwl, "CodingOwl", "Failed to load CodingOwl streaks.")} />
+              <Route path="/dashboard/matchmaker" element={withErrorBoundary(Matchmaker, "Matchmaker", "Failed to find developer matches.")} />
+              <Route path="/dashboard/friends" element={withErrorBoundary(Friends, "Friends", "Failed to load your social network.")} />
+              <Route path="/dashboard/friends/leaderboard" element={withErrorBoundary(Friends, "Friends Leaderboard", "Failed to load friends leaderboard.")} />
+              <Route path="/dashboard/friends/followers" element={withErrorBoundary(Friends, "Followers", "Failed to load followers list.")} />
+              <Route path="/dashboard/friends/following" element={withErrorBoundary(Friends, "Following", "Failed to load following list.")} />
+              <Route path="/dashboard/profile" element={withErrorBoundary(Profile, "Profile", "Your profile data failed to load.")} />
+              <Route path="/dashboard/profile/card-builder" element={withErrorBoundary(CardBuilder, "Card Builder", "Failed to initialize the dev card builder.")} />
+              <Route path="/dashboard/profile/:username" element={withErrorBoundary(Profile, "User Profile", "This developer's profile failed to load.")} />
+              <Route path="/dashboard/settings" element={<SettingsPage />} />
+              <Route path="/dashboard/auditor" element={withErrorBoundary(Auditor, "Auditor", "Security audit logs failed to load.")} />
+            </Route>
 
-          {/* 404 Catch All */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </Suspense>
+            {/* 404 Catch All */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
+      </FirestoreCacheProvider>
       <GlobalModals />
     </>
   );

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,11 @@ export default defineConfig({
             if (id.includes('framer-motion')) {
               return 'vendor-motion';
             }
+
+            // Swiper (Carousel)
+            if (id.includes('swiper')) {
+              return 'vendor-swiper';
+            }
             
             // All other node_modules
             return 'vendor';


### PR DESCRIPTION
### Description
Addresses #438 by mitigating excessive Firestore read charges caused by redundant listener tear-downs during same-session route navigation.

### Key Additions
* **`FirestoreCacheContext.jsx`:** Created a dedicated Context-backed store that persists across route unmounts, managing custom TTL cache maps.
* **`useFirestoreCache` Hook:** Engineered a custom SWR (Stale-While-Revalidate) hook that immediately returns memory-cached query results for instant UI paint, whilst silently revalidating via `getDocs` in the background. It uses deep-comparison to trigger re-renders only if actual data mutates.
* **`GitRank.jsx` Optimization:** Successfully ripped out the expensive `onSnapshot` real-time listener and replaced it with a `getDocs` driven fetch function wrapped in the new caching layer. Included local state synchronization to ensure the infinite-scroll pagination (`startAfter`) logic remains functional within the cached bounds.
* **App Shell Scope:** Wrapped the overarching `<AppRoutes />` inside the `<FirestoreCacheProvider>` to ensure the memory map is globally accessible for future pages.

Fixes #438