### PR TITLE
fix: order leaderboard by totalPoints desc and add role suggestions to autocomplete

### DIFF
--- a/src/services/friendsService.js
+++ b/src/services/friendsService.js
@@ -6,6 +6,7 @@ import {
   query, 
   where, 
   limit,
+  orderBy,
   documentId,
   writeBatch,
   increment
@@ -15,11 +16,15 @@ import { db } from "../lib/firebase";
 // Total number of distributed shards to handle high-concurrency increments
 const SHARD_COUNT = 5;
 
-// Asynchronously fetch real users from Firebase (capped at 50 to avoid
-// downloading the entire collection on every page load)
+// Asynchronously fetch real users from Firebase ordered by totalPoints descending
+// (capped at 50 to avoid downloading the entire collection on every page load)
 export const fetchDevelopers = async () => {
   try {
-    const q = query(collection(db, "users"), limit(50));
+    const q = query(
+      collection(db, "users"),
+      orderBy("points.totalPoints", "desc"),
+      limit(50)
+    );
     const querySnapshot = await getDocs(q);
     return querySnapshot.docs.map(doc => {
       const data = doc.data();
@@ -117,7 +122,7 @@ export const toggleFollowStatus = async (currentUserId, developerId, isFollowing
 
   try {
     if (isFollowing) {
-// Unfollow
+      // Unfollow
       batch.delete(followRef);
       // Decrement the distributed shard counter atomically
       batch.set(globalConnectionsShardRef, { count: increment(-1) }, { merge: true });

--- a/src/utils/searchUtils.js
+++ b/src/utils/searchUtils.js
@@ -143,6 +143,7 @@ export const getSearchSuggestions = (users, query) => {
         });
       }
     }
+
     if (username.toLowerCase().startsWith(searchTerm)) {
       const key = `username:${username}`;
       if (!suggestionsMap.has(key)) {
@@ -153,6 +154,7 @@ export const getSearchSuggestions = (users, query) => {
         });
       }
     }
+
     if (user.language && user.language.toLowerCase().includes(searchTerm)) {
       const key = `language:${user.language}`;
       if (!suggestionsMap.has(key)) {
@@ -160,6 +162,18 @@ export const getSearchSuggestions = (users, query) => {
           type: "language",
           value: user.language,
           display: `Language: ${user.language}`
+        });
+      }
+    }
+
+    // Role suggestions added to match searchLeaderboard and searchUsers behaviour
+    if (user.role && user.role.toLowerCase().includes(searchTerm)) {
+      const key = `role:${user.role}`;
+      if (!suggestionsMap.has(key)) {
+        suggestionsMap.set(key, {
+          type: "role",
+          value: user.role,
+          display: `Role: ${user.role}`
         });
       }
     }


### PR DESCRIPTION
Fixes #444 

## Problems

### 1. fetchDevelopers returns unordered users
`query(collection(db, "users"), limit(50))` had no `orderBy` clause. Firestore returns documents in internal document ID order, not by rank. The leaderboard was showing 50 arbitrary users instead of the actual top 50.

### 2. getSearchSuggestions missing role field
`searchLeaderboard()` and `searchUsers()` both filter by `user.role`, but `getSearchSuggestions()` only generated suggestions for name, username, and language. Typing "frontend" or "backend" returned search results but no autocomplete hints — inconsistent UX.

## Fixes
- Added `orderBy("points.totalPoints", "desc")` before `limit(50)` in `fetchDevelopers()` and imported `orderBy` from firebase/firestore
- Added role suggestion block in `getSearchSuggestions()` consistent with existing name, username, and language suggestion patterns

## Files changed
- `src/services/friendsService.js`
- `src/utils/searchUtils.js`