### PR TITLE
fix: Handle GitHub Events API pagination to preserve streaks for highly active developers

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -456,21 +456,46 @@ export const AuthProvider = ({ children }) => {
 
       let githubStreak = 0;
       try {
-        const eventsRes = await axios.get(`https://api.github.com/users/${username}/events?per_page=100`, { headers });
-        const events = eventsRes.data;
-        
-        const eventDates = new Set(
-          events
-            .filter(e => e.created_at)
-            .map(e => e.created_at.split('T')[0])
-        );
-        
         const today = new Date();
         const todayStr = today.toISOString().split('T')[0];
         
         const yesterday = new Date(today);
         yesterday.setDate(yesterday.getDate() - 1);
         const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+        const eventDates = new Set();
+        let eventsUrl = `https://api.github.com/users/${username}/events?per_page=100`;
+
+        while (eventsUrl) {
+          const eventsRes = await axios.get(eventsUrl, { headers });
+          const events = eventsRes.data;
+          
+          if (!events || events.length === 0) {
+            break;
+          }
+
+          let oldestEventDateStr = null;
+
+          events.forEach(e => {
+            if (e.created_at) {
+              const dateStr = e.created_at.split('T')[0];
+              eventDates.add(dateStr);
+              oldestEventDateStr = dateStr;
+            }
+          });
+
+          if (oldestEventDateStr && oldestEventDateStr < yesterdayStr) {
+            break;
+          }
+
+          const linkHeader = eventsRes.headers?.link || eventsRes.headers?.Link;
+          if (linkHeader) {
+            const nextLinkMatch = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+            eventsUrl = nextLinkMatch ? nextLinkMatch[1] : null;
+          } else {
+            eventsUrl = null;
+          }
+        }
 
         let dateToCheck = new Date(today);
         


### PR DESCRIPTION
## Description
This PR fixes a bug where highly active developers lose their GitHub streak because the client only fetches the first 100 events from the GitHub Events API. For users with >100 events in a single day, "yesterday's" events are pushed to the second page, causing the streak calculation to fail and incorrectly reset the streak.

Closes #430

## Changes Made
- Modified `fetchGitHubStats` in `src/context/AuthContext.jsx` to recursively fetch paginated GitHub events.
- Utilizes the `Link` header provided by GitHub to identify the `next` page of events.
- Added a condition to break the loop as soon as the event dates cross the `yesterdayStr` boundary safely, ensuring we don't fetch unnecessary pages while guaranteeing that consecutive days are tracked accurately.

## Testing
- Verified the logic correctly parses the `Link` header and fetches subsequent pages until an event older than yesterday is encountered.
