### PR TITLE
fix: resolve stale state concurrency bug in streak transaction overwriting hubCoins

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -84,7 +84,7 @@ const checkAndUpdateStreak = async (data, docRef) => {
         lastLogin: currentNow.toISOString(),
         "points.streakPoints": newStreakPoints,
         "points.totalPoints": newTotalPoints,
-        hubCoins: (data.hubCoins || 0) + 10
+        hubCoins: (latestData.hubCoins || 0) + 10
       });
     });
   } catch (err) {


### PR DESCRIPTION


**Description:**

### Bug Description
Closes #429

The `checkAndUpdateStreak` function utilized a Firestore `runTransaction` block to ensure atomicity. However, when writing the updated document, it calculated the new `hubCoins` using the stale parameter from outside the transaction (`data.hubCoins`) instead of the freshly read state from inside the transaction (`latestData.hubCoins`).

This resulted in a concurrency bug: if a user spent HubCoins (e.g., buying a mascot) or earned them right before the background streak transaction executed, the transaction would overwrite their balance with the old, cached value, unintentionally reverting their recent purchases or earnings.

### Changes Made
- Updated the transaction update payload in `src/context/AuthContext.jsx` to use `latestData.hubCoins` (the freshly read state inside the transaction block) rather than the `data` parameter passed to the function.
- Preserved the nullish coalescing check `|| 0` to ensure safe numeric addition.
