### PR TITLE
Fix #428: Include githubStreak in gitRankPoints formula

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -87,7 +87,8 @@ service cloud.firestore {
             request.resource.data.points.gitRankPoints == (
               request.resource.data.githubStats.commits * 2 +
               request.resource.data.githubStats.prs * 5 +
-              request.resource.data.githubStats.reviews * 10
+              request.resource.data.githubStats.reviews * 10 +
+              request.resource.data.githubStreak * 10
             ) &&
             request.resource.data.points.codingVersePoints == resource.data.points.codingVersePoints &&
             request.resource.data.points.streakPoints == resource.data.points.streakPoints &&


### PR DESCRIPTION

**Title:** Fix #428: Include githubStreak in gitRankPoints formula

**Description:**

### Bug Description
This PR resolves issue #428 where background GitHub sync was failing for active users with a "Permission Denied" error. There was a mismatch in the `gitRankPoints` calculation between the client-side code in `AuthContext.jsx` and the server-side validation rule in `firestore.rules`. 

The client calculated points with the user's active GitHub streak included, while the security rule strictly enforced a formula that omitted it. This caused the database to reject batch writes when syncing GitHub data for any user with a `githubStreak > 0`.

### Changes Made
- Updated the `gitRankPoints` validation formula in `firestore.rules` (around line 87) to correctly mirror the client-side calculation by adding `request.resource.data.githubStreak * 10`.

### Related Issue
Closes #428
