### PR TITLE
fix: enforce affectedKeys on points threshold rule (#427)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -80,7 +80,18 @@ service cloud.firestore {
             request.resource.data.points.totalPoints > resource.data.points.totalPoints && 
             request.resource.data.points.totalPoints - resource.data.points.totalPoints <= 200 &&
             // HubCoins can increase by at most the same amount as points (e.g. +10 HubCoins for +100 XP)
-            (request.resource.data.hubCoins != null ? request.resource.data.hubCoins : 500) - (resource.data.hubCoins != null ? resource.data.hubCoins : 500) <= (request.resource.data.points.totalPoints - resource.data.points.totalPoints)
+            (request.resource.data.hubCoins != null ? request.resource.data.hubCoins : 500) - (resource.data.hubCoins != null ? resource.data.hubCoins : 500) <= (request.resource.data.points.totalPoints - resource.data.points.totalPoints) &&
+            // SECURITY FIX: Ensure only allowed progression fields are modified
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+              'points',
+              'hubCoins',
+              'solvedCodingVerseQuestions',
+              'attemptedCodingVerseQuestions',
+              'codingVerseAnswers',
+              'codingVerseStreak',
+              'lastCodingVerseSolveDate',
+              'lastAuditReward'
+            ])
           ) ||
           // GitHub stats formula sync
           (


### PR DESCRIPTION
## Description
Closes #427 - Critical Security Bypass in points threshold rules.

In `firestore.rules`, the `update` block permitted users to increment their points (e.g., up to +200 points for CodingVerse Hard challenges). However, the rule did not restrict which other document fields could be modified during this same database write. This created a vulnerability where a malicious client could piggyback unauthorized edits (such as artificially inflating their `longestStreak` or granting unearned badges) while still satisfying the points limit check.

## Changes Made
- Added a strict `affectedKeys().hasOnly(...)` check to the specific `firestore.rules` block handling the `<= 200` points exception.
- Ensured that only legitimate progression fields utilized in the `CodingVerse.jsx` and `Auditor.jsx` workflows are permitted during this specific update condition:
  - `points`
  - `hubCoins`
  - `solvedCodingVerseQuestions`
  - `attemptedCodingVerseQuestions`
  - `codingVerseAnswers`
  - `codingVerseStreak`
  - `lastCodingVerseSolveDate`
  - `lastAuditReward`

## Testing Done
- Verified the exact fields emitted during legitimate CodingVerse challenge submissions and Auditor reward claims.
- Verified that the updated `firestore.rules` successfully blocks the update if unauthorized top-level fields are appended to the payload.
