### PR TITLE
fix: retrieve GitHub token from AuthContext instead of sessionStorage (#426)

### DIFF
--- a/src/pages/Matchmaker.jsx
+++ b/src/pages/Matchmaker.jsx
@@ -70,7 +70,7 @@ const STATIC_FALLBACK_ISSUES = [
 ];
 
 export const Matchmaker = () => {
-  const { user } = useAuth();
+  const { user, ghAccessToken } = useAuth();
 
   // Selected State
   const [selectedLanguage, setSelectedLanguage] = useState("javascript");
@@ -102,8 +102,7 @@ export const Matchmaker = () => {
     setRateLimited(false);
 
     // Retrieve authentication token if available
-    const token = sessionStorage.getItem(`gh_token_${user?.uid}`);
-    const headers = token ? { Authorization: `token ${token}` } : {};
+    const headers = ghAccessToken ? { Authorization: `token ${ghAccessToken}` } : {};
 
     // Get current parameters
     const difficultyObj = DIFFICULTIES.find(d => d.id === selectedDifficulty) || DIFFICULTIES[0];
@@ -161,7 +160,7 @@ export const Matchmaker = () => {
     } finally {
       setLoading(false);
     }
-  }, [selectedLanguage, selectedDifficulty, searchQuery, user]);
+  }, [selectedLanguage, selectedDifficulty, searchQuery, user, ghAccessToken]);
 
   // Load issues on initial component mounting
   useEffect(() => {


### PR DESCRIPTION
## Description
Closes #426 - Matchmaker API encounters frequent 403 Rate Limit errors due to sessionStorage token mismatch.

In `Matchmaker.jsx`, the application was previously attempting to retrieve the user's GitHub access token from `sessionStorage` to authenticate requests to the GitHub Search API. However, for security reasons, the GitHub token is stored exclusively in React state memory within `AuthContext.jsx` and is not persisted to `sessionStorage`. As a result, the Matchmaker fell back to unauthenticated queries, quickly hitting the strict global limit of 10 requests per minute per IP, which caused immediate 403 Forbidden errors and triggered static fallback data.

## Changes Made
- Destructured `ghAccessToken` directly from the `useAuth()` hook in `Matchmaker.jsx`.
- Replaced the failing `sessionStorage.getItem()` lookup with the `ghAccessToken` variable to populate the API Authorization headers.
- Added `ghAccessToken` to the dependency array of the `fetchIssues` callback to ensure queries refresh appropriately when the token state updates.

## Testing Done
- Verified that `ghAccessToken` is successfully destructured from the context and securely populates the Authorization header.
- Confirmed that Matchmaker queries are now successfully executed against the GitHub Search API utilizing the authenticated rate limit (30 requests/min), preventing the 403 errors.
