### PR TITLE
fix(UI): add light mode styling for sidebar (fixes #425)

### DIFF
--- a/src/components/layout/MobileSidebar.jsx
+++ b/src/components/layout/MobileSidebar.jsx
@@ -88,12 +88,12 @@ export const MobileSidebar = ({ isOpen, close }) => {
               animate={{ x: 0 }}
               exit={{ x: "-100%" }}
               transition={{ type: "spring", stiffness: 300, damping: 30 }}
-              className="fixed top-0 bottom-0 left-0 w-72 max-w-[80vw] z-50 bg-slate-950 border-r border-slate-800/50 shadow-2xl flex flex-col md:hidden transition-colors duration-300 text-slate-400"
+              className="fixed top-0 bottom-0 left-0 w-72 max-w-[80vw] z-50 bg-white dark:bg-slate-950 border-r border-slate-200 dark:border-slate-800/50 shadow-2xl flex flex-col md:hidden transition-colors duration-300 text-slate-600 dark:text-slate-400"
             >
               {/* Header */}
-              <div className="h-16 flex items-center justify-between px-5 border-b border-slate-800/50">
+              <div className="h-16 flex items-center justify-between px-5 border-b border-slate-200 dark:border-slate-800/50">
                 <Link to="/" onClick={close} className="flex items-center gap-2.5">
-                  <div className="w-[34px] h-[34px] rounded-full overflow-hidden flex-shrink-0 flex items-center justify-center bg-slate-900 border border-slate-800/50 shadow-md">
+                  <div className="w-[34px] h-[34px] rounded-full overflow-hidden flex-shrink-0 flex items-center justify-center bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800/50 shadow-md">
                     <img src={logo} alt="RankerHub Logo" className="w-full h-full object-cover" />
                   </div>
                   <span className="font-montserrat font-extrabold text-lg bg-clip-text text-transparent bg-gradient-to-r from-violet-400 to-blue-400 tracking-tight">
@@ -104,7 +104,7 @@ export const MobileSidebar = ({ isOpen, close }) => {
                 {/* Close button */}
                 <button
                   onClick={close}
-                  className="p-1.5 rounded-lg border border-slate-800/50 hover:bg-slate-800 text-slate-500 cursor-pointer"
+                  className="p-1.5 rounded-lg border border-slate-200 dark:border-slate-800/50 hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 dark:text-slate-500 cursor-pointer"
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -125,13 +125,13 @@ export const MobileSidebar = ({ isOpen, close }) => {
                     >
                       <div
                         className={`
-                          flex items-center gap-3 px-3.5 py-3 rounded-xl text-sm font-semibold transition-colors duration-205
+                          flex items-center gap-3 px-3.5 py-3 rounded-xl text-sm font-semibold transition-colors duration-205 group
                           ${isActive
                             ? "text-white bg-gradient-to-r from-violet-600 to-indigo-600 shadow-[0_4px_15px_rgba(124,58,237,0.25)]"
-                            : "text-slate-400 hover:text-slate-100 hover:bg-slate-800/40"}
+                            : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-800/40"}
                         `}
                       >
-                        <IconComponent className={`w-5 h-5 ${isActive ? "text-white" : "text-slate-400 group-hover:text-violet-400 transition-colors"}`} />
+                        <IconComponent className={`w-5 h-5 ${isActive ? "text-white" : "text-slate-400 dark:text-slate-400 group-hover:text-violet-600 dark:group-hover:text-violet-400 transition-colors"}`} />
                         <span>{link.label}</span>
                       </div>
                     </Link>
@@ -140,12 +140,12 @@ export const MobileSidebar = ({ isOpen, close }) => {
               </div>
 
               {/* Logout */}
-              <div className="p-4 border-t border-slate-800/50">
+              <div className="p-4 border-t border-slate-200 dark:border-slate-800/50">
                 <button
                   onClick={handleLogout}
-                  className="w-full flex items-center gap-3 px-3.5 py-3 rounded-xl text-sm font-semibold text-red-400 hover:bg-red-500/10 transition-colors cursor-pointer group"
+                  className="w-full flex items-center gap-3 px-3.5 py-3 rounded-xl text-sm font-semibold text-red-500 dark:text-red-400 hover:bg-red-50/80 dark:hover:bg-red-500/10 transition-colors cursor-pointer group"
                 >
-                  <LogOut className="w-5 h-5 text-red-400 group-hover:text-red-300" />
+                  <LogOut className="w-5 h-5 text-red-500 dark:text-red-400 group-hover:text-red-600 dark:group-hover:text-red-300 transition-colors" />
                   <span>Logout</span>
                 </button>
               </div>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -74,12 +74,12 @@ export const Sidebar = ({ isCollapsed, toggleCollapse }) => {
       <motion.aside
         animate={{ width: isCollapsed ? 76 : 260 }}
         transition={{ duration: 0.3, ease: "easeInOut" }}
-        className="hidden md:flex flex-col h-screen fixed left-0 top-0 z-40 border-r border-slate-800/50 bg-slate-950 backdrop-blur-xl transition-colors duration-300 text-slate-400"
+        className="hidden md:flex flex-col h-screen fixed left-0 top-0 z-40 border-r border-slate-200 dark:border-slate-800/50 bg-white dark:bg-slate-950 backdrop-blur-xl transition-colors duration-300 text-slate-600 dark:text-slate-400"
       >
         {/* Sidebar Header / Logo */}
-        <div className="h-16 flex items-center justify-between px-4 border-b border-slate-800/50">
+        <div className="h-16 flex items-center justify-between px-4 border-b border-slate-200 dark:border-slate-800/50">
           <Link to="/" className="flex items-center gap-2.5 overflow-hidden">
-            <div className="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 flex items-center justify-center bg-slate-900 border border-slate-800/50 shadow-md">
+            <div className="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 flex items-center justify-center bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800/50 shadow-md">
               <img src={logo} alt="RankerHub Logo" className="w-full h-full object-cover" />
             </div>
             <AnimatePresence>
@@ -99,14 +99,14 @@ export const Sidebar = ({ isCollapsed, toggleCollapse }) => {
           {/* Collapse Button */}
           <button
             onClick={toggleCollapse}
-            className="p-1.5 rounded-lg border border-slate-800/50 hover:bg-slate-800/60 text-slate-500 hover:text-slate-200 cursor-pointer"
+            className="p-1.5 rounded-lg border border-slate-200 dark:border-slate-800/50 hover:bg-slate-100 dark:hover:bg-slate-800/60 text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer"
           >
             {isCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
           </button>
         </div>
 
         {/* Navigation Links */}
-        <div className="flex-1 py-6 px-3 space-y-1.5 overflow-y-auto scrollbar-thin scrollbar-thumb-slate-800">
+        <div className="flex-1 py-6 px-3 space-y-1.5 overflow-y-auto scrollbar-thin scrollbar-thumb-slate-300 dark:scrollbar-thumb-slate-800">
           {sidebarLinks.map((link) => {
             const IconComponent = iconMap[link.icon] || Home;
             const isActive = isLinkActive(location.pathname, link.path);
@@ -123,10 +123,10 @@ export const Sidebar = ({ isCollapsed, toggleCollapse }) => {
                     flex items-center gap-3 px-3 py-3 rounded-xl text-sm font-semibold transition-colors duration-200 group
                     ${isActive 
                       ? "text-white bg-gradient-to-r from-violet-600 to-indigo-600 shadow-[0_4px_15px_rgba(124,58,237,0.25)]" 
-                      : "text-slate-400 hover:text-slate-100 hover:bg-slate-800/50"}
+                      : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-800/50"}
                   `}
                 >
-                  <IconComponent className={`w-5 h-5 flex-shrink-0 ${isActive ? "text-white" : "text-slate-400 group-hover:text-violet-400 transition-colors"}`} />
+                  <IconComponent className={`w-5 h-5 flex-shrink-0 ${isActive ? "text-white" : "text-slate-400 dark:text-slate-400 group-hover:text-violet-600 dark:group-hover:text-violet-400 transition-colors"}`} />
                   
                   {!isCollapsed && (
                     <motion.span
@@ -151,10 +151,10 @@ export const Sidebar = ({ isCollapsed, toggleCollapse }) => {
         </div>
 
         {/* Sidebar Footer / Theme & Logout */}
-        <div className="p-3 border-t border-slate-800/50 space-y-2">
+        <div className="p-3 border-t border-slate-200 dark:border-slate-800/50 space-y-2">
           <div className={`flex items-center ${isCollapsed ? "justify-center" : "justify-between px-3"} py-2`}>
             {!isCollapsed && (
-              <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+              <span className="text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider">
                 Theme
               </span>
             )}
@@ -163,9 +163,9 @@ export const Sidebar = ({ isCollapsed, toggleCollapse }) => {
 
           <button
             onClick={handleLogout}
-            className="w-full flex items-center gap-3 px-3 py-3 rounded-xl text-sm font-semibold text-red-400 hover:bg-red-500/10 transition-colors duration-200 cursor-pointer group"
+            className="w-full flex items-center gap-3 px-3 py-3 rounded-xl text-sm font-semibold text-red-500 dark:text-red-400 hover:bg-red-50/80 dark:hover:bg-red-500/10 transition-colors duration-200 cursor-pointer group"
           >
-            <LogOut className="w-5 h-5 flex-shrink-0 text-red-400 group-hover:text-red-300" />
+            <LogOut className="w-5 h-5 flex-shrink-0 text-red-500 dark:text-red-400 group-hover:text-red-600 dark:group-hover:text-red-300 transition-colors" />
             {!isCollapsed && (
               <motion.span
                 initial={{ opacity: 0 }}


### PR DESCRIPTION
## Description

Closes #425

The current sidebar was hardcoded to use dark-themed colors (`bg-slate-950`, `border-slate-800/50`, etc.), meaning it did not adapt to the overall light theme of the application and caused visual inconsistency. 

This PR implements full light mode support for both the Desktop `Sidebar` and `MobileSidebar` components. 

### Changes Made:
- **Backgrounds**: Updated sidebar backgrounds to `bg-white` for light mode while preserving `dark:bg-slate-950`.
- **Borders & Dividers**: Replaced dark borders with `border-slate-200` in light mode, mapping to `dark:border-slate-800/50` for dark mode.
- **Text & Icons**: 
  - Adjusted default text and icon colors to `text-slate-600` for better readability on light backgrounds.
  - Ensured active and hover states blend nicely in light mode (`hover:bg-slate-100`, `hover:text-slate-900`) while maintaining the original dark mode styling.
- **Logout Button**: Swapped to a slightly more visible red (`text-red-500`) with a lighter hover background (`hover:bg-red-50/80`) in light mode.

## Screenshots

<img width="1919" height="910" alt="Screenshot 2026-06-13 122704" src="https://github.com/user-attachments/assets/15bb4be7-300d-4127-9136-da3f4e8d8063" />


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
