### PR TITLE
feat: add scroll-to-top button for leaderboard and friends pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import AppRoutes from "./routes/AppRoutes";
 import ErrorBoundary from "./components/ui/ErrorBoundary";
 import RateLimitBanner from "./components/ui/RateLimitBanner";
 import Preloader from "./components/ui/Preloader";
+import ScrollToTop from "./components/ui/ScrollToTop";
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
               <Preloader />
               <RateLimitBanner />
               <AppRoutes />
+              <ScrollToTop />
             </HashRouter>
           </RateLimitProvider>
         </AuthProvider>

--- a/src/components/ui/ScrollToTop.jsx
+++ b/src/components/ui/ScrollToTop.jsx
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from "react";
+import { ChevronUp } from "lucide-react";
+
+const ScrollToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 300);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      className="fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition-all hover:bg-blue-700 hover:scale-105 active:scale-95"
+      aria-label="Scroll to top"
+    >
+      <ChevronUp size={24} />
+    </button>
+  );
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
Adds a floating scroll-to-top button that appears after scrolling past 300px. This helps users navigate back to the top of long leaderboard and friends list pages.

Closes #485