### PR TITLE
fix: prevent stale heatmap cache and show error state on RankHer subscription failure

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -105,7 +105,7 @@ export const Dashboard = () => {
           const cacheAge = now - cacheEntry.timestamp;
           const fifteenMinutes = 15 * 60 * 1000;
 
-          if (cacheAge < fifteenMinutes || err.message.includes("API")) {
+          if (cacheAge < fifteenMinutes && err.message.includes("API")) {
             data = cacheEntry.data;
           }
         }

--- a/src/pages/RankHer.jsx
+++ b/src/pages/RankHer.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useAuth } from '../context/AuthContext';
-import { Sparkles, Quote, Star, Loader2 } from "lucide-react";
+import { AlertTriangle, Sparkles, Quote, Star, Loader2 } from "lucide-react";
 import { collection, query, where, orderBy, limit, onSnapshot } from "firebase/firestore";
 import { db } from "../lib/firebase";
 import Card from "../components/ui/Card";
@@ -12,6 +12,7 @@ const { user, userData } = useAuth();
   // []    = subscription returned, zero qualifying users
   // [...] = real users ranked by totalPoints
   const [womenUsers, setWomenUsers] = useState(null);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const q = query(
@@ -33,6 +34,7 @@ const { user, userData } = useAuth();
       },
       (error) => {
         console.error("RankHer leaderboard subscription error:", error);
+        setError(error.message || "Failed to load rankings");
         setWomenUsers([]);
       }
     );
@@ -41,6 +43,20 @@ const { user, userData } = useAuth();
   }, []);
 
   const renderBody = () => {
+    if (error) {
+      return (
+        <Card className="p-8 text-center border-red-200 dark:border-red-800/40">
+          <AlertTriangle className="w-10 h-10 text-red-400 mx-auto mb-3" />
+          <p className="text-sm font-semibold text-red-500 dark:text-red-400">
+            Unable to load rankings
+          </p>
+          <p className="text-xs text-slate-400 mt-1">
+            {error}. Please try again later.
+          </p>
+        </Card>
+      );
+    }
+
     if (womenUsers === null) {
       return (
         <div className="flex items-center justify-center py-12 text-slate-400">


### PR DESCRIPTION
Two fixes in this PR:

## 1. Stale heatmap cache (Closes #476)

The fetchHeatmap fallback condition used || between cacheAge and err.message.includes('API'). Since the thrown error is constructed as `API Error: ${res.status}`, the 'API' check is always true on any non-OK response, so cached data was served regardless of age.

**Fix:** Changed || to && so cached data is only served when the cache is fresh AND the error is API-related.

## 2. RankHer error state (Closes #477)

The onSnapshot error handler set womenUsers to [], which displayed the same 'No rankings yet' empty state as a genuinely empty leaderboard on Firestore errors (e.g. missing composite index).

**Fix:** Added a separate error state that renders an error card with the error message, distinct from the empty state.