### PR TITLE
fix: remove duplicate hash fragment in HashRouter redirect (#364)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
   useEffect(() => {
     const path = window.location.pathname;
     if (path !== '/' && path !== '/index.html') {
-      window.location.replace('/#' + path + window.location.hash);
+      window.location.replace('/#' + path);
     }
   }, []);
 


### PR DESCRIPTION
## Description
Removed `window.location.hash` from the HashRouter redirect logic 
in `App.jsx` to prevent duplicate hash fragments like 
`/#/dashboard#/dashboard` from being generated.

## Related Issue
Fixes #364

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
[Add screenshot of URL bar showing clean redirect without double hash]

## Testing Done
- [x] Visual verification on local dev server (`http://localhost:5173`)
- [x] Navigating to app with hash URL redirects cleanly ✅
- [x] No double hash fragments in URL ✅
- [x] No console errors or warnings

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the Contributing Guidelines and Code of Conduct.