### PR TITLE
fix: add auth loading state to prevent route flicker (#365)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { HashRouter } from "react-router-dom";
 import { ThemeProvider } from "./context/ThemeContext";
-import { AuthProvider } from "./context/AuthContext";
+import { AuthProvider, useAuth } from "./context/AuthContext";
 import { RateLimitProvider } from "./context/RateLimitContext";
 import AppRoutes from "./routes/AppRoutes";
 import ErrorBoundary from "./components/ui/ErrorBoundary";
@@ -9,12 +9,23 @@ import RateLimitBanner from "./components/ui/RateLimitBanner";
 import Preloader from "./components/ui/Preloader";
 import ScrollToTop from "./components/ui/ScrollToTop";
 
+const AppContent = () => {
+  const { loading } = useAuth();
+  if (loading) return <Preloader />;
+  return (
+    <>
+      <ScrollToTop />
+      <RateLimitBanner />
+      <AppRoutes />
+    </>
+  );
+};
+
 function App() {
-  // Convert pathname to hash router format to prevent routing bugs
   useEffect(() => {
     const path = window.location.pathname;
     if (path !== '/' && path !== '/index.html') {
-      window.location.replace('/#' + path + window.location.hash);
+      window.location.replace('/#' + path);
     }
   }, []);
 
@@ -25,9 +36,7 @@ function App() {
           <RateLimitProvider>
             <HashRouter>
               <Preloader />
-              <RateLimitBanner />
-              <AppRoutes />
-              <ScrollToTop />
+              <AppContent />
             </HashRouter>
           </RateLimitProvider>
         </AuthProvider>


### PR DESCRIPTION
## Description
Added an `AppContent` inner component that uses `useAuth` hook 
to check `loading` state before rendering `AppRoutes`. This 
prevents route flicker and premature redirects to login page 
while Firebase auth state is being resolved.

**Changes:**
- Created `AppContent` component inside `App.jsx` that reads 
  `loading` from `useAuth()`
- Shows `<Preloader />` while auth is loading
- Renders `<AppRoutes />` only after auth state is resolved
- Also fixed duplicate hash fragment issue in redirect logic

## Related Issue
Fixes #365

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
[Add screen recording showing no flicker on page refresh]

## Testing Done
- [x] Visual verification on local dev server (`http://localhost:5173`)
- [x] Refreshed page while logged in — no login page flash ✅
- [x] Auth state resolves correctly before routes render ✅
- [x] No console errors or warnings

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the Contributing Guidelines and Code of Conduct.