### PR TITLE
fix: remove StrictMode to prevent double Firebase API calls (#366)

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,7 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+  <App />
 )


### PR DESCRIPTION
## Description
Removed `StrictMode` wrapper from `src/main.jsx` to prevent 
double Firebase API calls (`onSnapshot`, `getDoc`, etc.) in 
development mode that could lead to rate limiting issues.

**Changes:**
- Removed `StrictMode` import from `main.jsx`
- Removed `<StrictMode>` wrapper around `<App />`
- Firebase calls now fire once per component mount ✅

## Related Issue
Fixes #366

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Videos (if applicable)
[Add screenshot of console showing single Firebase calls]

## Testing Done
- [x] Visual verification on local dev server (`http://localhost:5173`)
- [x] Firebase calls fire only once on page load ✅
- [x] No rate limiting errors in console ✅
- [x] App works correctly without StrictMode ✅
- [x] No console errors or warnings

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

## Contributor Declaration
- [x] I confirm that this contribution is made under the rules of **NSoC 2026**.
- [x] I confirm that I have been assigned the related issue by a maintainer before opening this PR.
- [x] I have read the Contributing Guidelines and Code of Conduct.