### PR TITLE
fix: make logout modal theme-aware instead of always dark

### DIFF
--- a/src/components/ui/LogoutConfirmModal.jsx
+++ b/src/components/ui/LogoutConfirmModal.jsx
@@ -12,7 +12,7 @@ export const LogoutConfirmModal = ({ onClose, onConfirm }) => {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         onClick={onClose}
-        className="absolute inset-0 bg-slate-950/60 backdrop-blur-md"
+        className="absolute inset-0 bg-black/40 dark:bg-slate-950/60 backdrop-blur-md"
       />
 
       {/* Modal Box */}
@@ -20,7 +20,7 @@ export const LogoutConfirmModal = ({ onClose, onConfirm }) => {
         initial={{ opacity: 0, scale: 0.95, y: 20 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.95, y: 20 }}
-        className="relative w-full max-w-md bg-slate-900/90 dark:bg-slate-950/90 border border-slate-800/80 rounded-3xl shadow-2xl p-6 text-slate-100 flex flex-col items-center text-center gap-6"
+        className="relative w-full max-w-md bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-3xl shadow-2xl p-6 text-slate-900 dark:text-slate-100 flex flex-col items-center text-center gap-6"
       >
         {/* Warning Icon Banner */}
         <div className="w-14 h-14 rounded-2xl bg-amber-500/10 border border-amber-500/20 flex items-center justify-center text-amber-500">
@@ -29,8 +29,8 @@ export const LogoutConfirmModal = ({ onClose, onConfirm }) => {
 
         {/* Header */}
         <div className="space-y-1">
-          <h3 className="text-xl font-black text-white my-0">Confirm Logout</h3>
-          <p className="text-xs text-slate-400 font-semibold leading-relaxed">
+          <h3 className="text-xl font-black text-slate-900 dark:text-white my-0">Confirm Logout</h3>
+          <p className="text-xs text-slate-500 dark:text-slate-400 font-semibold leading-relaxed">
             Are you sure you want to log out of RankerHub? You will need to sign in again to access your developer overview stats.
           </p>
         </div>
@@ -39,7 +39,7 @@ export const LogoutConfirmModal = ({ onClose, onConfirm }) => {
         <div className="flex gap-4 w-full">
           <button
             onClick={onClose}
-            className="flex-1 py-3 text-xs font-bold rounded-xl border border-slate-800 hover:bg-slate-800 text-slate-400 hover:text-white transition cursor-pointer"
+            className="flex-1 py-3 text-xs font-bold rounded-xl border border-slate-300 dark:border-slate-800 hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition cursor-pointer"
           >
             Cancel
           </button>


### PR DESCRIPTION
The LogoutConfirmModal used hardcoded dark backgrounds (bg-slate-900) regardless of the active theme. Updated to use theme-aware classes:\n- bg-white dark:bg-slate-900 for the modal\n- Proper text colors for light/dark modes\n- Theme-aware borders and hover states\n- Semi-transparent backdrop in light mode\n\nCloses #517