### PR TITLE
fix: respect persisted sidebar collapse preference on resize for desktop widths

### DIFF
--- a/src/hooks/useSidebar.js
+++ b/src/hooks/useSidebar.js
@@ -12,13 +12,12 @@ export const useSidebar = () => {
     localStorage.setItem("sidebar_collapsed", JSON.stringify(isCollapsed));
   }, [isCollapsed]);
 
-  // Automatically collapse sidebar on tablet screens, and reset mobile drawer on resize
+  // Automatically collapse sidebar on tablet/narrow screens, and reset mobile drawer on resize.
+  // On wider (desktop) screens, do not override the user's persisted collapse preference.
   useEffect(() => {
     const handleResize = () => {
       if (window.innerWidth < 1024) {
         setIsCollapsed(true);
-      } else {
-        setIsCollapsed(false);
       }
       if (window.innerWidth >= 768) {
         setIsMobileOpen(false);


### PR DESCRIPTION
Fixes #496

Problem:
useSidebar initializes isCollapsed from localStorage ("sidebar_collapsed"), but a resize effect ran handleResize() immediately on mount and on every resize, unconditionally setting isCollapsed to false for widths >= 1024px — overriding the user's saved preference every time.

Fix:
Removed the unconditional "else { setIsCollapsed(false) }" branch. Narrow screens (<1024px) still force-collapse the sidebar for responsiveness, but desktop widths no longer reset isCollapsed, so the localStorage-restored value (or the user's manual toggle) persists correctly.

Files changed:
- src/hooks/useSidebar.js

Testing:
- Collapsed the sidebar on desktop width, refreshed the page — sidebar remains collapsed.
- Resized to <1024px — sidebar still auto-collapses as expected.
- Resized back to >=1024px — collapsed state from before is preserved, not reset.