### PR TITLE
fix: calculateRankingBreakdown reads correct Firestore fields instead of always returning 0

### DIFF
--- a/src/utils/rankingBreakdown.js
+++ b/src/utils/rankingBreakdown.js
@@ -7,7 +7,7 @@ export const calculateRankingBreakdown = (userData) => {
   if (!userData) {
     return {
       gitPoints: { total: 0, commits: 0, prs: 0, reviews: 0, githubStreak: 0, explanation: "No GitHub activity yet" },
-      codingVersePoints: { total: 0, easy: 0, medium: 0, hard: 0, explanation: "Complete challenges to earn points" },
+      codingVersePoints: { total: 0, explanation: "Complete challenges to earn points" },
       streakPoints: { total: 0, dailyStreak: 0, maxCap: 100, explanation: "Daily login streak (max 100 XP per cycle)" },
       referralPoints: { total: 0, successfulReferrals: 0, explanation: "Earn 100 XP per successful referral" },
       totalPoints: 0,
@@ -16,14 +16,14 @@ export const calculateRankingBreakdown = (userData) => {
   }
 
   const points = userData.points || {};
-  
-  // Git Points Breakdown
-  const gitStats = userData.gitStats || {};
-  const commits = gitStats.commits || 0;
-  const prs = gitStats.pullRequests || 0;
-  const reviews = gitStats.reviews || 0;
-  const githubStreak = gitStats.streak || 0;
-  
+
+  // Git Points Breakdown (read from the actual schema: userData.githubStats + userData.githubStreak)
+  const githubStats = userData.githubStats || {};
+  const commits = githubStats.commits || 0;
+  const prs = githubStats.prs || 0;
+  const reviews = githubStats.reviews || 0;
+  const githubStreak = userData.githubStreak || 0;
+
   const gitPointsDetail = {
     commits: commits * 2,
     prs: prs * 5,
@@ -35,27 +35,19 @@ export const calculateRankingBreakdown = (userData) => {
     explanation: `GitHub contributions: ${commits} commits × 2 + ${prs} PRs × 5 + ${reviews} reviews × 10 + ${githubStreak} streak × 10`
   };
 
-  // Coding Verse Points Breakdown
-  const challenges = userData.challenges || {};
-  const easyCompleted = challenges.easy || 0;
-  const mediumCompleted = challenges.medium || 0;
-  const hardCompleted = challenges.hard || 0;
+  // Coding Verse Points Breakdown (precomputed total stored on points.codingVersePoints;
+  // per-difficulty completion counts aren't tracked separately in Firestore)
+  const codingVersePointsTotal = points.codingVersePoints || 0;
 
   const codingVerseDetail = {
-    easy: easyCompleted * 100,
-    medium: mediumCompleted * 150,
-    hard: hardCompleted * 200,
-    get total() {
-      return this.easy + this.medium + this.hard;
-    },
-    challengeCount: easyCompleted + mediumCompleted + hardCompleted,
-    explanation: `Challenge completions: ${easyCompleted} Easy × 100 + ${mediumCompleted} Medium × 150 + ${hardCompleted} Hard × 200`
+    total: codingVersePointsTotal,
+    explanation: `CodingVerse Arena challenges solved: ${codingVersePointsTotal} XP earned`
   };
 
-  // Streak Points Breakdown
-  const currentStreak = userData.currentStreak || 0;
+  // Streak Points Breakdown (read from userData.streak, the live login streak)
+  const currentStreak = userData.streak || 0;
   const maxStreakCap = 100;
-  
+
   const streakDetail = {
     dailyStreak: currentStreak * 10,
     maxCap: maxStreakCap,
@@ -66,19 +58,20 @@ export const calculateRankingBreakdown = (userData) => {
     explanation: `Daily login streak: ${currentStreak} consecutive days × 10 XP (capped at ${maxStreakCap} XP per cycle)`
   };
 
-  // Referral Points Breakdown
-  const successfulReferrals = userData.referralStats?.successful || 0;
+  // Referral Points Breakdown (derive successful referral count from points.referralPoints,
+  // since each successful referral awards 100 XP to the referrer)
+  const referralPointsTotal = points.referralPoints || 0;
+  const successfulReferrals = Math.floor(referralPointsTotal / 100);
+
   const referralDetail = {
-    successfulReferrals: successfulReferrals,
-    get total() {
-      return this.successfulReferrals * 100;
-    },
+    successfulReferrals,
+    total: referralPointsTotal,
     explanation: `Successful referrals: ${successfulReferrals} × 100 XP per person`
   };
 
-  // Calculate totals
-  const totalFromBreakdown = gitPointsDetail.total + codingVerseDetail.total + streakDetail.total + referralDetail.total;
-  
+  // Use the authoritative totalPoints from Firestore to stay consistent with the rest of the app
+  const totalFromBreakdown = points.totalPoints || 0;
+
   // Build detailed breakdown array for UI
   const pointsBreakdown = [
     {
@@ -95,19 +88,17 @@ export const calculateRankingBreakdown = (userData) => {
       category: "💻 Coding Challenges",
       points: codingVerseDetail.total,
       details: [
-        { label: "Easy Challenges", value: easyCompleted, multiplier: 100, total: codingVerseDetail.easy },
-        { label: "Medium Challenges", value: mediumCompleted, multiplier: 150, total: codingVerseDetail.medium },
-        { label: "Hard Challenges", value: hardCompleted, multiplier: 200, total: codingVerseDetail.hard }
+        { label: "CodingVerse XP", value: codingVersePointsTotal, multiplier: 1, total: codingVersePointsTotal }
       ]
     },
     {
       category: "🔥 Daily Streak",
       points: streakDetail.total,
       details: [
-        { 
-          label: "Consecutive Days", 
-          value: currentStreak, 
-          multiplier: 10, 
+        {
+          label: "Consecutive Days",
+          value: currentStreak,
+          multiplier: 10,
           total: streakDetail.dailyStreak,
           note: `Capped at ${maxStreakCap} XP per cycle`
         }
@@ -144,7 +135,7 @@ export const calculateRankingBreakdown = (userData) => {
  */
 export const getRankExplanation = (breakdown) => {
   const { totalPoints, pointsBreakdown } = breakdown;
-  
+
   if (pointsBreakdown.length === 0) {
     return "Start earning points by completing challenges, contributing to GitHub, or logging in daily!";
   }


### PR DESCRIPTION
Fixes #498

Problem:
calculateRankingBreakdown read from fields that don't exist on real user documents (userData.gitStats, userData.challenges, userData.currentStreak, userData.referralStats.successful), causing every category total to be 0 and the "Why is my rank this value?" breakdown to always show the empty state, regardless of the user's actual XP.

Fix:
Remapped all reads to the actual schema used throughout the app:
- GitHub stats: userData.githubStats.commits/prs/reviews and userData.githubStreak
- CodingVerse points: userData.points.codingVersePoints (shown as a single XP line, since per-difficulty counts aren't stored separately)
- Daily streak: userData.streak
- Referral points: userData.points.referralPoints, with successful referral count derived as referralPoints / 100
- totalPoints now uses userData.points.totalPoints directly for consistency with the rest of the app

Files changed:
- src/utils/rankingBreakdown.js

Testing:
- Verified with a user having non-zero githubStats, points.codingVersePoints, streak, and points.referralPoints — breakdown now shows correct non-zero categories matching the Dashboard/Profile totals.
- Verified the empty-state (no userData) path still returns the original zeroed structure.
- Confirmed RankingBreakdown.jsx remains compatible — it only consumes category.points and category.details (label/value/multiplier/total/note), which the updated function still provides in the same shape.