### PR TITLE
[Bug]: Fix streak calculation by using user timezone instead of UTC dates

### DIFF
--- a/src/__tests__/streakCalculator.test.js
+++ b/src/__tests__/streakCalculator.test.js
@@ -1,47 +1,167 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
+import {
+  toLocalDateString,
+  addDaysToDateString,
+  calculateGithubStreak,
+  evaluateLoginStreak,
+  evaluateCodingVerseStreak,
+} from "../utils/streakCalculator";
 
-// Core logic wrapper for testing - FIXED WITH UTC METHODS
-const checkAndUpdateStreak = (lastLoginIso, currentLoginIso, currentStreak) => {
-  const last = new Date(lastLoginIso);
-  last.setUTCHours(0, 0, 0, 0); // Force UTC midnight to avoid local timezone drift
+describe("toLocalDateString", () => {
+  it("maps UTC timestamps to the correct local calendar day", () => {
+    // Jan 1 11:55 PM Pacific = Jan 2 07:55 UTC
+    expect(toLocalDateString("2026-01-02T07:55:00Z", "America/Los_Angeles")).toBe(
+      "2026-01-01"
+    );
+  });
 
-  const current = new Date(currentLoginIso);
-  current.setUTCHours(0, 0, 0, 0); // Force UTC midnight
+  it("maps late-night Asia/Kolkata contributions to the local day", () => {
+    // 11:55 PM IST on June 1 = 18:25 UTC on June 1
+    expect(toLocalDateString("2026-06-01T18:25:00Z", "Asia/Kolkata")).toBe(
+      "2026-06-01"
+    );
+  });
 
-  const diffInDays = Math.round((current - last) / (1000 * 60 * 60 * 24));
+  it("maps early-morning IST contributions that fall on the prior UTC day", () => {
+    // 2:00 AM IST on June 2 = 20:30 UTC on June 1
+    expect(toLocalDateString("2026-06-01T20:30:00Z", "Asia/Kolkata")).toBe(
+      "2026-06-02"
+    );
+  });
+});
 
-  if (diffInDays === 0) return { streak: currentStreak, updated: false };
-  if (diffInDays === 1) return { streak: currentStreak + 1, updated: true };
-  return { streak: 1, updated: true };
-};
+describe("calculateGithubStreak", () => {
+  it("counts consecutive local days instead of UTC days", () => {
+    const events = [
+      "2026-01-02T07:55:00Z", // Jan 1 local (America/Los_Angeles)
+      "2026-01-02T16:00:00Z", // Jan 2 local morning
+    ];
+    const referenceDate = new Date("2026-01-02T20:00:00Z"); // Jan 2 local
 
-describe('Streak Calculator Logic', () => {
-  it('should increment streak by 1 for a valid consecutive daily check-in', () => {
-    const result = checkAndUpdateStreak('2026-06-01T10:00:00Z', '2026-06-02T10:00:00Z', 5);
+    expect(calculateGithubStreak(events, "America/Los_Angeles", referenceDate)).toBe(
+      2
+    );
+    // UTC-only grouping would treat both events as Jan 2 → streak of 1
+    expect(calculateGithubStreak(events, "UTC", referenceDate)).toBe(1);
+  });
+
+  it("preserves streak when user contributed yesterday in local time", () => {
+    const events = ["2026-06-01T18:25:00Z"]; // June 1 11:55 PM IST
+    const referenceDate = new Date("2026-06-02T10:00:00Z"); // June 2 afternoon IST
+
+    expect(calculateGithubStreak(events, "Asia/Kolkata", referenceDate)).toBe(1);
+  });
+
+  it("returns 0 when there is no activity today or yesterday locally", () => {
+    const events = ["2026-06-01T10:00:00Z"];
+    const referenceDate = new Date("2026-06-03T10:00:00Z");
+
+    expect(calculateGithubStreak(events, "Asia/Kolkata", referenceDate)).toBe(0);
+  });
+
+  it("handles leap year boundaries", () => {
+    const events = ["2024-02-28T12:00:00Z", "2024-02-29T12:00:00Z"];
+    const referenceDate = new Date("2024-02-29T18:00:00Z");
+
+    expect(calculateGithubStreak(events, "UTC", referenceDate)).toBe(2);
+  });
+});
+
+describe("evaluateLoginStreak", () => {
+  it("increments streak for consecutive local calendar days", () => {
+    const result = evaluateLoginStreak(
+      "2026-06-01T10:00:00+05:30",
+      "2026-06-02T10:00:00+05:30",
+      5,
+      "Asia/Kolkata"
+    );
     expect(result.streak).toBe(6);
     expect(result.updated).toBe(true);
   });
 
-  it('should reset streak to 1 if a day is missed completely', () => {
-    const result = checkAndUpdateStreak('2026-06-01T10:00:00Z', '2026-06-03T10:00:00Z', 5);
+  it("resets streak when a local day is missed", () => {
+    const result = evaluateLoginStreak(
+      "2026-06-01T10:00:00Z",
+      "2026-06-03T10:00:00Z",
+      5,
+      "UTC"
+    );
     expect(result.streak).toBe(1);
     expect(result.updated).toBe(true);
   });
 
-  it('should not update streak for multiple check-ins on the exact same day', () => {
-    const result = checkAndUpdateStreak('2026-06-01T08:00:00Z', '2026-06-01T18:00:00Z', 5);
+  it("does not update streak for multiple logins on the same local day", () => {
+    const result = evaluateLoginStreak(
+      "2026-06-01T08:00:00Z",
+      "2026-06-01T18:00:00Z",
+      5,
+      "UTC"
+    );
     expect(result.streak).toBe(5);
     expect(result.updated).toBe(false);
   });
 
-  it('should handle leap year boundary correctly (Feb 28 to Feb 29)', () => {
-    const result = checkAndUpdateStreak('2024-02-28T12:00:00Z', '2024-02-29T12:00:00Z', 10);
-    expect(result.streak).toBe(11);
+  it("treats logins on the same local Pacific day as one day", () => {
+    const result = evaluateLoginStreak(
+      "2026-01-02T07:55:00Z", // Jan 1 11:55 PM Pacific
+      "2026-01-02T07:59:00Z", // Jan 1 11:59 PM Pacific
+      3,
+      "America/Los_Angeles"
+    );
+    expect(result.streak).toBe(3);
+    expect(result.updated).toBe(false);
   });
 
-  it('should handle midnight timezone boundaries without breaking streaks', () => {
-    // Crosses day boundary in UTC but might be only 2 hours apart real-time
-    const result = checkAndUpdateStreak('2026-06-01T23:00:00Z', '2026-06-02T01:00:00Z', 1);
+  it("counts cross-midnight local logins as consecutive days", () => {
+    const result = evaluateLoginStreak(
+      "2026-01-02T07:55:00Z", // Jan 1 11:55 PM Pacific
+      "2026-01-02T16:00:00Z", // Jan 2 8:00 AM Pacific
+      1,
+      "America/Los_Angeles"
+    );
     expect(result.streak).toBe(2);
+    expect(result.updated).toBe(true);
+  });
+});
+
+describe("evaluateCodingVerseStreak", () => {
+  it("starts a new streak on first solve day", () => {
+    const result = evaluateCodingVerseStreak(null, 0, "UTC", new Date("2026-06-01T12:00:00Z"));
+    expect(result).toEqual({
+      streak: 1,
+      lastSolveDate: "2026-06-01",
+      earnedStreakPoints: 5,
+      progressed: true,
+    });
+  });
+
+  it("extends streak across local day boundaries", () => {
+    const result = evaluateCodingVerseStreak(
+      "2026-01-01",
+      2,
+      "America/Los_Angeles",
+      new Date("2026-01-02T16:00:00Z")
+    );
+    expect(result.streak).toBe(3);
+    expect(result.lastSolveDate).toBe("2026-01-02");
+    expect(result.progressed).toBe(true);
+  });
+
+  it("does not progress when already solved today locally", () => {
+    const result = evaluateCodingVerseStreak(
+      "2026-06-01",
+      4,
+      "Asia/Kolkata",
+      new Date("2026-06-01T12:00:00Z") // still June 1 in IST
+    );
+    expect(result.streak).toBe(4);
+    expect(result.earnedStreakPoints).toBe(0);
+    expect(result.progressed).toBe(false);
+  });
+});
+
+describe("addDaysToDateString", () => {
+  it("steps backward across month boundaries", () => {
+    expect(addDaysToDateString("2026-03-01", -1)).toBe("2026-02-28");
   });
 });

--- a/src/components/dashboard/StreakCard.jsx
+++ b/src/components/dashboard/StreakCard.jsx
@@ -50,16 +50,11 @@ export const StreakCard = () => {
       if (dayDateStr === todayStr) {
         status = loggedInToday ? "completed" : "current";
       } else if (dayDate < now) {
-<<<<<<< HEAD
-        // Past day — infer completion from active streak length
+        // Past day — infer completion from active streak length (timezone-aware)
         const dayMs = Date.parse(`${dayDateStr}T12:00:00Z`);
         const todayMs = Date.parse(`${todayStr}T12:00:00Z`);
         const diffDays = Math.round((todayMs - dayMs) / (1000 * 60 * 60 * 24));
-        const maxCompletedDiff = loggedInToday ? activeStreak - 1 : activeStreak;
-=======
-        // Past day
         const maxCompletedDiff = Math.max(0, loggedInToday ? activeStreak - 1 : activeStreak);
->>>>>>> main
         if (diffDays >= 0 && diffDays <= maxCompletedDiff) {
           status = "completed";
         }

--- a/src/components/dashboard/StreakCard.jsx
+++ b/src/components/dashboard/StreakCard.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Flame, Check } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
 import Card from "../ui/Card";
+import { toLocalDateString, resolveTimezone } from "../../utils/streakCalculator";
 
 export const StreakCard = () => {
   const { userData } = useAuth();
@@ -9,11 +10,13 @@ export const StreakCard = () => {
   const activeStreak = userData?.streak || 0;
   const longestStreak = Math.max(userData?.longestStreak || 0, activeStreak);
   
-  // Calculate today's status
+  // Calculate today's status using the user's stored timezone
   const now = new Date();
-  const todayStr = now.toDateString();
+  const timeZone = resolveTimezone(userData?.timezone);
+  const todayStr = toLocalDateString(now, timeZone);
   const lastLogin = userData?.lastLogin ? new Date(userData?.lastLogin) : null;
-  const loggedInToday = lastLogin && lastLogin.toDateString() === todayStr;
+  const loggedInToday =
+    lastLogin && toLocalDateString(lastLogin, timeZone) === todayStr;
   
   const dailyProgressMins = loggedInToday ? 60 : 0;
   const dailyGoalMins = 60;
@@ -40,14 +43,17 @@ export const StreakCard = () => {
       const dayStr = daysOfWeek[i];
       const dateLabel = dayDate.toLocaleDateString("en-US", { month: "short", day: "numeric" });
       
-      let status = "pending";
-      const diffTime = now.getTime() - dayDate.getTime();
-      const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24));
+      const dayDateStr = toLocalDateString(dayDate, timeZone);
 
-      if (dayDate.toDateString() === todayStr) {
+      let status = "pending";
+
+      if (dayDateStr === todayStr) {
         status = loggedInToday ? "completed" : "current";
       } else if (dayDate < now) {
-        // Past day
+        // Past day — infer completion from active streak length
+        const dayMs = Date.parse(`${dayDateStr}T12:00:00Z`);
+        const todayMs = Date.parse(`${todayStr}T12:00:00Z`);
+        const diffDays = Math.round((todayMs - dayMs) / (1000 * 60 * 60 * 24));
         const maxCompletedDiff = loggedInToday ? activeStreak - 1 : activeStreak;
         if (diffDays >= 0 && diffDays <= maxCompletedDiff) {
           status = "completed";

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -22,6 +22,14 @@ import { auth, db, signInWithGitHub, signOutUser } from "../lib/firebase";
 import { validateUserData } from "../utils/inputValidation";
 import { userDataCache, listenerOptimizer } from "../utils/firestoreOptimization";
 import { calculateTrustScore } from "../services/trustScoreService";
+import {
+  calculateGithubStreak,
+  detectTimezone,
+  resolveTimezone,
+  toLocalDateString,
+  addDaysToDateString,
+  evaluateLoginStreak,
+} from "../utils/streakCalculator";
 
 const AuthContext = createContext({});
 
@@ -30,9 +38,13 @@ export const useAuth = () => useContext(AuthContext);
 const checkAndUpdateStreak = async (data, docRef) => {
   if (!data || data.onboardingStatus !== "complete") return;
   const now = new Date();
+  const timeZone = resolveTimezone(data.timezone);
   const lastLoginDate = data.lastLogin ? new Date(data.lastLogin) : null;
 
-  if (lastLoginDate && lastLoginDate.toDateString() === now.toDateString()) {
+  if (
+    lastLoginDate &&
+    toLocalDateString(lastLoginDate, timeZone) === toLocalDateString(now, timeZone)
+  ) {
     return;
   }
 
@@ -43,30 +55,32 @@ const checkAndUpdateStreak = async (data, docRef) => {
 
       const latestData = userDoc.data();
       const currentNow = new Date();
+      const latestTimeZone = resolveTimezone(latestData.timezone);
       const latestLastLogin = latestData.lastLogin ? new Date(latestData.lastLogin) : null;
 
-      if (latestLastLogin && latestLastLogin.toDateString() === currentNow.toDateString()) {
+      if (
+        latestLastLogin &&
+        toLocalDateString(latestLastLogin, latestTimeZone) ===
+          toLocalDateString(currentNow, latestTimeZone)
+      ) {
         return;
       }
 
-      let newStreak = latestData.streak || 1;
+      const streakUpdate = evaluateLoginStreak(
+        latestLastLogin?.toISOString() ?? null,
+        currentNow.toISOString(),
+        latestData.streak || 1,
+        latestTimeZone
+      );
+
+      const newStreak = streakUpdate.streak;
       let newStreakPoints = latestData.points?.streakPoints || 0;
-
-      if (latestLastLogin) {
-        const yesterday = new Date(currentNow);
-        yesterday.setDate(yesterday.getDate() - 1);
-
-        const lastLoginDateStr = latestLastLogin.toDateString();
-        const yesterdayStr = yesterday.toDateString();
-
-        if (lastLoginDateStr === yesterdayStr) {
-          newStreak += 1;
-          newStreakPoints += 10;
-        } else {
-          newStreak = 1;
-        }
-      } else {
-        newStreak = 1;
+      if (
+        streakUpdate.updated &&
+        latestLastLogin &&
+        newStreak === (latestData.streak || 1) + 1
+      ) {
+        newStreakPoints += 10;
       }
 
       const newTotalPoints =
@@ -81,6 +95,7 @@ const checkAndUpdateStreak = async (data, docRef) => {
         streak: newStreak,
         longestStreak: newLongestStreak,
         lastLogin: currentNow.toISOString(),
+        timezone: latestTimeZone,
         "points.streakPoints": newStreakPoints,
         "points.totalPoints": newTotalPoints,
         hubCoins: (data.hubCoins || 0) + 10
@@ -139,6 +154,7 @@ export const AuthProvider = ({ children }) => {
               streak: 0,
               longestStreak: 0,
               githubStreak: 0,
+              timezone: detectTimezone(),
               lastLogin: new Date().toISOString(),
               createdAt: new Date().toISOString(),
               points: {
@@ -156,7 +172,7 @@ export const AuthProvider = ({ children }) => {
           } else {
             await setDoc(
               userDocRef,
-              { lastLogin: new Date().toISOString() },
+              { lastLogin: new Date().toISOString(), timezone: detectTimezone() },
               { merge: true }
             );
           }
@@ -380,7 +396,7 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
-  const fetchGitHubStats = async (uid, username) => {
+  const fetchGitHubStats = async (uid, username, timeZone) => {
     if (!username || typeof username !== "string") {
       throw new Error("GitHub username is required and must be a string.");
     }
@@ -493,19 +509,15 @@ export const AuthProvider = ({ children }) => {
         console.warn("Reviews retrieval failed:", err);
       }
 
-      // --- Streak calculation ---
+      // --- Streak calculation (user-local calendar days) ---
       let githubStreak = 0;
       let eventsList = [];
+      const streakTimeZone = resolveTimezone(timeZone);
 
       try {
-        const today = new Date();
-        const todayStr = today.toISOString().split("T")[0];
-
-        const yesterday = new Date(today);
-        yesterday.setDate(yesterday.getDate() - 1);
-        const yesterdayStr = yesterday.toISOString().split("T")[0];
-
-        const eventDates = new Set();
+        const todayStr = toLocalDateString(new Date(), streakTimeZone);
+        const yesterdayStr = addDaysToDateString(todayStr, -1);
+        const eventTimestamps = [];
 
         let eventsUrl = `https://api.github.com/users/${encodedUsername}/events?per_page=100`;
         let firstPageLoaded = false;
@@ -524,38 +536,19 @@ export const AuthProvider = ({ children }) => {
 
           if (!events.length) break;
 
-          let oldestEventDateStr = null;
+          let oldestEventLocalDateStr = null;
           events.forEach((e) => {
             if (e.created_at) {
-              const dateStr = e.created_at.split("T")[0];
-              eventDates.add(dateStr);
-              oldestEventDateStr = dateStr;
+              eventTimestamps.push(e.created_at);
+              const localDateStr = toLocalDateString(e.created_at, streakTimeZone);
+              oldestEventLocalDateStr = localDateStr;
             }
           });
 
-          if (oldestEventDateStr && oldestEventDateStr < yesterdayStr) break;
+          if (oldestEventLocalDateStr && oldestEventLocalDateStr < yesterdayStr) break;
         }
 
-        let dateToCheck = new Date(today);
-        if (eventDates.has(todayStr)) {
-          // active today — start streak from today
-        } else if (eventDates.has(yesterdayStr)) {
-          dateToCheck = new Date(yesterday);
-        } else {
-          dateToCheck = null;
-        }
-
-        if (dateToCheck) {
-          while (true) {
-            const checkStr = dateToCheck.toISOString().split("T")[0];
-            if (eventDates.has(checkStr)) {
-              githubStreak++;
-              dateToCheck.setDate(dateToCheck.getDate() - 1);
-            } else {
-              break;
-            }
-          }
-        }
+        githubStreak = calculateGithubStreak(eventTimestamps, streakTimeZone);
       } catch (err) {
         console.warn("GitHub events retrieval failed for streak:", err);
       }
@@ -627,7 +620,11 @@ export const AuthProvider = ({ children }) => {
     }
 
     try {
-      const ghStats = await fetchGitHubStats(user.uid, userData.githubUsername);
+      const ghStats = await fetchGitHubStats(
+        user.uid,
+        userData.githubUsername,
+        userData.timezone
+      );
       const userRef = doc(db, "users", user.uid);
 
       const userDoc = await getDoc(userRef);

--- a/src/pages/CodingVerse.jsx
+++ b/src/pages/CodingVerse.jsx
@@ -16,7 +16,8 @@ import Card from "../components/ui/Card";
 import SectionHeader from "../components/ui/SectionHeader";
 import { useAuth } from "../context/AuthContext";
 import { db } from "../lib/firebase";
-import { doc, updateDoc, runTransaction, query, collection, where, getCountFromServer, getDocs } from "firebase/firestore";
+import { doc, runTransaction, query, collection, where, getCountFromServer, getDocs } from "firebase/firestore";
+import { evaluateCodingVerseStreak } from "../utils/streakCalculator";
 
 // --- Language Definitions ---
 const LANGUAGES = [
@@ -675,31 +676,14 @@ export const CodingVerse = () => {
               newSolvedQuestions = [...liveAnswered, qId];
               newCodingVersePoints += earnedPoints;
 
-              // Ensure timezone-agnostic boundaries using strict UTC Date strings
-              const today = new Date();
-              const todayUTCStr = today.toISOString().split('T')[0];
-              const todayUTC = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
-
-              if (newLastCodingVerseSolveDate) {
-                if (todayUTCStr !== newLastCodingVerseSolveDate) {
-                  const lastDateParts = newLastCodingVerseSolveDate.split('-');
-                  const lastUTC = Date.UTC(parseInt(lastDateParts[0]), parseInt(lastDateParts[1]) - 1, parseInt(lastDateParts[2]));
-                  const diffDays = Math.floor((todayUTC - lastUTC) / (1000 * 60 * 60 * 24));
-
-                  if (diffDays === 1) {
-                    newCodingVerseStreak += 1; // Maintained consecutive sequence
-                  } else if (diffDays > 1) {
-                    newCodingVerseStreak = 1; // Broken streak, reset
-                  }
-                  earnedStreakPoints = 5; // +5 XP for each new active solving day
-                  newLastCodingVerseSolveDate = todayUTCStr;
-                }
-              } else {
-                newCodingVerseStreak = 1;
-                earnedStreakPoints = 5;
-                newLastCodingVerseSolveDate = todayUTCStr;
-              }
-
+              const streakResult = evaluateCodingVerseStreak(
+                newLastCodingVerseSolveDate,
+                newCodingVerseStreak,
+                liveData.timezone
+              );
+              newCodingVerseStreak = streakResult.streak;
+              newLastCodingVerseSolveDate = streakResult.lastSolveDate;
+              earnedStreakPoints = streakResult.earnedStreakPoints;
               newStreakPoints += earnedStreakPoints;
               newTotalPoints = (liveData.points?.gitRankPoints || 0) +
                               (liveData.points?.referralPoints || 0) +

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -310,7 +310,7 @@ export const GitRank = () => {
     setSyncError("");
 
     try {
-      const ghStats = await fetchGitHubStats(user.uid, userData.githubUsername);
+      const ghStats = await fetchGitHubStats(user.uid, userData.githubUsername, userData.timezone);
       const userRef = doc(db, "users", user.uid);
 
       await runTransaction(db, async (transaction) => {

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -25,6 +25,7 @@ import {
 } from "firebase/firestore";
 import { db } from "../lib/firebase";
 import { useAuth } from "../context/AuthContext";
+import { detectTimezone } from "../utils/streakCalculator";
 import Card from "../components/ui/Card";
 import GradientButton from "../components/ui/GradientButton";
 import collegesList from "../data/colleges.json";
@@ -233,7 +234,7 @@ export const Onboarding = () => {
 
       // 2. Fetch Verified GitHub Stats Snapshot
       setSuccessMsg("Snapshotting your GitHub contributions securely...");
-      const ghStats = await fetchGitHubStats(activeUid, githubUsername);
+      const ghStats = await fetchGitHubStats(activeUid, githubUsername, detectTimezone());
 
       setSuccessMsg("Validating referrals and locking account credentials...");
 
@@ -334,6 +335,7 @@ export const Onboarding = () => {
           referralCode: newReferralCode,
           referredBy: referrerUid ? referrerCodeClean : null,
           onboardingStatus: "complete",
+          timezone: detectTimezone(),
           streak: 1,
           lastLogin: new Date().toISOString(),
           createdAt: new Date().toISOString(),

--- a/src/utils/streakCalculator.js
+++ b/src/utils/streakCalculator.js
@@ -1,0 +1,160 @@
+/**
+ * Timezone-aware streak utilities.
+ * GitHub timestamps are UTC; streaks are evaluated on the user's local calendar day.
+ */
+
+export const detectTimezone = () => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+};
+
+export const isValidTimezone = (timeZone) => {
+  if (!timeZone || typeof timeZone !== "string") return false;
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const resolveTimezone = (timeZone) => {
+  if (isValidTimezone(timeZone)) return timeZone;
+  return detectTimezone();
+};
+
+/** @returns {string|null} YYYY-MM-DD in the given IANA timezone */
+export const toLocalDateString = (dateInput, timeZone) => {
+  const date = dateInput instanceof Date ? dateInput : new Date(dateInput);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: resolveTimezone(timeZone),
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+};
+
+/** Shift a calendar date string by a number of days (timezone-agnostic). */
+export const addDaysToDateString = (dateStr, days) => {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const shifted = new Date(Date.UTC(year, month - 1, day + days));
+  return shifted.toISOString().split("T")[0];
+};
+
+/**
+ * Calculate consecutive-day GitHub contribution streak from event timestamps.
+ * @param {string[]} eventTimestamps ISO-8601 strings from GitHub events
+ * @param {string} [timeZone] IANA timezone (defaults to browser)
+ * @param {Date} [referenceDate] "today" anchor (defaults to now)
+ */
+export const calculateGithubStreak = (
+  eventTimestamps,
+  timeZone,
+  referenceDate = new Date()
+) => {
+  const tz = resolveTimezone(timeZone);
+  const eventDates = new Set();
+
+  for (const ts of eventTimestamps) {
+    const localDate = toLocalDateString(ts, tz);
+    if (localDate) eventDates.add(localDate);
+  }
+
+  const todayStr = toLocalDateString(referenceDate, tz);
+  const yesterdayStr = addDaysToDateString(todayStr, -1);
+
+  const startDateStr = eventDates.has(todayStr)
+    ? todayStr
+    : eventDates.has(yesterdayStr)
+      ? yesterdayStr
+      : null;
+
+  if (!startDateStr) return 0;
+
+  let streak = 0;
+  let dateToCheck = startDateStr;
+  while (eventDates.has(dateToCheck)) {
+    streak += 1;
+    dateToCheck = addDaysToDateString(dateToCheck, -1);
+  }
+
+  return streak;
+};
+
+/**
+ * Daily login streak update based on local calendar days.
+ */
+export const evaluateLoginStreak = (
+  lastLoginIso,
+  currentLoginIso,
+  currentStreak,
+  timeZone
+) => {
+  const tz = resolveTimezone(timeZone);
+  const currentDateStr = toLocalDateString(currentLoginIso, tz);
+  const lastDateStr = lastLoginIso ? toLocalDateString(lastLoginIso, tz) : null;
+
+  if (!lastDateStr) {
+    return { streak: 1, updated: true };
+  }
+
+  if (lastDateStr === currentDateStr) {
+    return { streak: currentStreak, updated: false };
+  }
+
+  const yesterdayStr = addDaysToDateString(currentDateStr, -1);
+  if (lastDateStr === yesterdayStr) {
+    return { streak: currentStreak + 1, updated: true };
+  }
+
+  return { streak: 1, updated: true };
+};
+
+/**
+ * CodingVerse daily solve streak update based on local calendar days.
+ */
+export const evaluateCodingVerseStreak = (
+  lastSolveDateStr,
+  currentStreak,
+  timeZone,
+  referenceDate = new Date()
+) => {
+  const tz = resolveTimezone(timeZone);
+  const todayStr = toLocalDateString(referenceDate, tz);
+
+  if (!lastSolveDateStr) {
+    return {
+      streak: 1,
+      lastSolveDate: todayStr,
+      earnedStreakPoints: 5,
+      progressed: true,
+    };
+  }
+
+  if (lastSolveDateStr === todayStr) {
+    return {
+      streak: currentStreak,
+      lastSolveDate: lastSolveDateStr,
+      earnedStreakPoints: 0,
+      progressed: false,
+    };
+  }
+
+  const yesterdayStr = addDaysToDateString(todayStr, -1);
+  let newStreak = 1;
+  if (lastSolveDateStr === yesterdayStr) {
+    newStreak = currentStreak + 1;
+  }
+
+  return {
+    streak: newStreak,
+    lastSolveDate: todayStr,
+    earnedStreakPoints: 5,
+    progressed: true,
+  };
+};


### PR DESCRIPTION
GitHub records contribution activity using UTC timestamps, while RankerHub users view activity according to their local timezone.

### Example

* User Timezone: Asia/Kolkata (UTC+5:30)
* Contribution Time: 11:55 PM (Local Time)
* GitHub Timestamp: 06:25 PM UTC

When streak calculations use UTC dates directly, contributions may be attributed to a different calendar day than the user expects, causing valid streaks to appear broken.

## Changes

* Store and use the user's timezone during streak calculations.
* Convert GitHub contribution timestamps to the user's local timezone before evaluating daily activity.
* Base streak validation on local calendar days instead of raw UTC dates.
* Add test coverage for timezone conversions and day-boundary edge cases.

## Impact

### Before

* Users could lose streaks incorrectly.
* Daily contribution counts could be inaccurate.
* Users outside UTC were disproportionately affected.

### After

* Streak calculations respect the user's local timezone.
* Contributions near midnight are assigned to the correct local day.
* Streaks remain consistent with GitHub contribution activity.
* Improved accuracy and trust in contribution tracking.

## Acceptance Criteria

* [x] Streak calculations use the user's local timezone.
* [x] Contributions near midnight are assigned to the correct local day.
* [x] Streaks remain consistent with GitHub contribution activity.
* [x] Tests added for timezone and day-boundary scenarios.

## Fixes

Fixes #505
