### PR TITLE
fix: guard progressPercentage against NaN/Infinity in RankingBreakdown for zero-point users

### DIFF
--- a/src/components/dashboard/RankingBreakdown.jsx
+++ b/src/components/dashboard/RankingBreakdown.jsx
@@ -18,7 +18,9 @@ export const RankingBreakdown = ({ userData }) => {
     setExpandedCategory(expandedCategory === category ? null : category);
   };
 
-  const progressPercentage = (breakdown.totalPoints / breakdown.nextMilestone.points) * 100;
+  const progressPercentage = breakdown.nextMilestone.points > 0
+    ? (breakdown.totalPoints / breakdown.nextMilestone.points) * 100
+    : 0;
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
Fixes #530

Note: While investigating the originally reported emoji encoding issue, I found that the emoji characters in RankingBreakdown.jsx are actually correctly encoded as UTF-8 — the garbled appearance was a Windows CMD terminal rendering artifact, not a real file encoding bug.

However, while reviewing the file I found a real edge case worth fixing:

Problem:
progressPercentage was calculated as (breakdown.totalPoints / breakdown.nextMilestone.points) * 100 without guarding against division by zero. When a brand new user has totalPoints = 0, nextMilestone.points evaluates to Math.ceil(0 / 250) * 250 = 0, making the division 0/0 = NaN. This NaN is then passed to Math.min(progressPercentage, 100) and used as the width in the motion.div progress bar style (width: NaN%), producing invalid CSS and a broken progress bar for new users.

Fix:
Added a zero-guard so progressPercentage defaults to 0 when nextMilestone.points is 0, preventing NaN/Infinity from reaching the progress bar width style.

Files changed:
- src/components/dashboard/RankingBreakdown.jsx (progressPercentage calculation, line 21)

Testing:
- Verified the progress bar renders correctly (0% width) for a user with 0 total points.
- Verified the progress bar continues to render correctly for users with non-zero points.