### PR TITLE
feat: Add "Jump to My Rank" button on leaderboard

### DIFF
--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { Search, Filter, Star, Trophy, RefreshCw, GitCommit, Calendar, BookOpen, AlertCircle, CheckCircle2, Users, Medal, ShieldCheck } from "lucide-react";
-import { collection, query, doc, where, orderBy, limit, startAfter, onSnapshot, getDocs, runTransaction, serverTimestamp } from "firebase/firestore";
+import { collection, query, doc, where, orderBy, limit, startAfter, onSnapshot, getDocs, runTransaction, serverTimestamp, getCountFromServer } from "firebase/firestore";
 import { useSearchParams } from "react-router-dom";
 import { TableVirtuoso } from "react-virtuoso"; 
 import { db } from "../lib/firebase";
@@ -74,7 +74,50 @@ export const GitRank = () => {
   const [repos, setRepos] = useState([]);
   const [loadingCharts, setLoadingCharts] = useState(true);
   const [chartRateLimitError, setChartRateLimitError] = useState("");
+  // Jump to My Rank
+const [myRank, setMyRank] = useState(null);
+const [rankLoading, setRankLoading] = useState(false);
+const [rankError, setRankError] = useState("");
+const myRowRef = useRef(null);
 
+const handleJumpToMyRank = async () => {
+  if (!user) return;
+  setRankLoading(true);
+  setRankError("");
+  setMyRank(null);
+  try {
+    const userPoints = activeTab === "referrals"
+      ? (userData?.points?.referralPoints ?? 0)
+      : (userData?.points?.gitRankPoints ?? 0);
+
+    if (userPoints === 0) {
+      setRankError("You haven't earned any points yet! Start contributing 🚀");
+      setRankLoading(false);
+      return;
+    }
+
+    const pointsField = activeTab === "referrals"
+      ? "points.referralPoints"
+      : "points.gitRankPoints";
+
+    const q = query(
+      collection(db, "users"),
+      where(pointsField, ">", userPoints)
+    );
+    const snapshot = await getCountFromServer(q);
+    const rank = snapshot.data().count + 1;
+    setMyRank(rank);
+
+    setTimeout(() => {
+      myRowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 150);
+  } catch (err) {
+    console.error(err);
+    setRankError("Could not fetch your rank. Please try again.");
+  } finally {
+    setRankLoading(false);
+  }
+};
   const languages = ["All", "TypeScript", "Rust", "Go", "Python", "Kotlin", "Ruby", "JavaScript"];
 
   // 1. Real-time Leaderboard Listener (Server-Side Filtered)
@@ -988,8 +1031,34 @@ export const GitRank = () => {
 
       {/* 3. Leaderboard Table / Search & Filters Controls */}
       <Card className="!p-3 sm:!p-6">
-        
+       
+      {/* Jump to My Rank - Issue #483 */}
+{user && (
+  <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 mb-4">
+    <button
+      onClick={handleJumpToMyRank}
+      disabled={rankLoading}
+      className="flex items-center gap-2 px-4 py-2 rounded-xl bg-violet-600 hover:bg-violet-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-bold transition-colors shadow-md"
+    >
+      {rankLoading ? "⏳ Finding rank..." : "📍 My Rank"}
+    </button>
+
+    {myRank && (
+      <div className="px-4 py-2 rounded-xl bg-violet-50 dark:bg-violet-500/10 border border-violet-200 dark:border-violet-500/20 text-violet-700 dark:text-violet-300 text-xs font-bold flex items-center gap-2">
+        🏅 You are ranked <span className="text-violet-600 dark:text-violet-400 font-black">#{myRank}</span> on the leaderboard
+      </div>
+    )}
+
+    {rankError && (
+      <div className="px-4 py-2 rounded-xl bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20 text-amber-700 dark:text-amber-300 text-xs font-bold flex items-center gap-2">
+        ⚠️ {rankError}
+      </div>
+    )}
+  </div>
+)}
+      
         {/* NEW TAB SYSTEM FOR REFERRAL LEADERBOARD */}
+        
         <div className="flex items-center gap-2 mb-6 p-1 bg-slate-100 dark:bg-slate-800/50 rounded-xl w-fit">
           <button
             onClick={() => handleTabChange("gitrank")}
@@ -1077,7 +1146,17 @@ export const GitRank = () => {
               components={{
                 Table: (props) => <table {...props} className="w-full text-left mt-4 border-collapse min-w-[640px]" />,
                 TableHead: React.forwardRef((props, ref) => <thead {...props} ref={ref} />),
-                TableRow: (props) => <tr {...props} className="hover:bg-slate-50/50 dark:hover:bg-slate-900/20 transition-colors group" />,
+               TableRow: ({ item: u, ...props }) => (
+  <tr
+    {...props}
+    ref={user && u?.uid === user?.uid ? myRowRef : null}
+    className={`hover:bg-slate-50/50 dark:hover:bg-slate-900/20 transition-colors group ${
+      user && u?.uid === user?.uid && myRank
+        ? "bg-violet-50 dark:bg-violet-500/10 ring-2 ring-violet-400 ring-inset"
+        : ""
+    }`}
+  />
+),
                 TableBody: React.forwardRef((props, ref) => <tbody {...props} ref={ref} className="divide-y divide-slate-100 dark:divide-slate-800/40 text-sm" />),
               }}
               fixedHeaderContent={() => (


### PR DESCRIPTION
Closes #483

## Changes Made
- Added `useRef` and `getCountFromServer` imports
- Added `handleJumpToMyRank` function that queries Firestore to count users with more points
- Added `📍 My Rank` button above the leaderboard table
- Added rank banner showing "You are ranked #X"
- Added error message for users with 0 points
- Added highlight effect on current user's row when rank is found
- Works for both GitRank and Referrals tabs

## How to Test
1. Log in with GitHub
2. Go to GitRank leaderboard
3. Click 📍 My Rank button
4. Banner shows your rank and page scrolls to your highlighted row