### PR TITLE
fix: prevent leaderboard rank numbers flashing wrong positions on initial load

### DIFF
--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -110,6 +110,9 @@ export const GitRank = () => {
 
     const q = query(collection(db, "users"), ...constraints);
 
+    // Safety timeout: if Firestore cache is the only data source (e.g. offline), show data after 5s
+    const loadingTimeout = setTimeout(() => setLoadingUsers(false), 5000);
+
     const unsubscribe = onSnapshot(
       q,
       (snapshot) => {
@@ -125,16 +128,24 @@ export const GitRank = () => {
 
         setUsersList(ranked);
         setLastVisible(snapshot.docs[snapshot.docs.length - 1]);
-        setHasMore(snapshot.docs.length === 50); 
-        setLoadingUsers(false);
+        setHasMore(snapshot.docs.length === 50);
+        // Only stop loading on server data to avoid rendering cached (potentially unsorted) data first
+        if (!snapshot.metadata.fromCache) {
+          clearTimeout(loadingTimeout);
+          setLoadingUsers(false);
+        }
       },
       (error) => {
         console.error("Leaderboard subscription error:", error);
+        clearTimeout(loadingTimeout);
         setLoadingUsers(false);
       }
     );
 
-    return () => unsubscribe();
+    return () => {
+      clearTimeout(loadingTimeout);
+      unsubscribe();
+    };
   }, [selectedLanguage, activeTab, selectedCollege]); 
 
   // Pagination Function (Fetch next 50)


### PR DESCRIPTION
## Description

Fixes #552

The leaderboard uses Firestore `onSnapshot` which fires twice on page load:
1. First with cached data (instant) — sorting may be incomplete
2. Then with correct server data

Previously, the loading state was removed after the **first** callback, causing the rank numbers to display incorrect positions for a brief moment before jumping to the correct order.

## Change

- Only hide the loading spinner when the data comes from the **server** (`snapshot.metadata.fromCache === false`)
- Added a 5-second safety timeout so offline users don't see a permanent spinner

## Testing

- Load the leaderboard — no more rank flicker on initial render
- Rank numbers should appear stable from the moment data is shown