### PR TITLE
fix: sync profile avatar across open tabs via localStorage

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { githubFetch, getRateLimitMessage } from "../utils/githubRateLimit";
-import React, { createContext, useContext, useState, useEffect } from "react";
+import React, { createContext, useContext, useState, useEffect, useRef } from "react";
 import {
   onAuthStateChanged,
   getAdditionalUserInfo,
@@ -95,6 +95,18 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(auth ? true : false);
   const [isOnboarding, setIsOnboarding] = useState(false);
   const [ghAccessToken, setGhAccessToken] = useState(null);
+  const uidRef = useRef(null);
+
+  // Cross-tab avatar sync: listen for avatar updates from other tabs
+  useEffect(() => {
+    const handleStorage = (e) => {
+      if (e.key?.startsWith('rh_avatar_') && e.newValue && e.key.replace('rh_avatar_', '') === uidRef.current) {
+        setUserData(prev => prev ? { ...prev, avatar: e.newValue } : prev);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
   useEffect(() => {
     if (!auth) {
@@ -169,6 +181,7 @@ export const AuthProvider = ({ children }) => {
 
       if (currentUser) {
         setUser(currentUser);
+        uidRef.current = currentUser.uid;
 
         const userDocRef = doc(db, "users", currentUser.uid);
 
@@ -210,6 +223,7 @@ export const AuthProvider = ({ children }) => {
         setUserData(null);
         setIsOnboarding(false);
         setLoading(false);
+        uidRef.current = null;
       }
     });
 

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -245,6 +245,8 @@ export const Profile = () => {
           ...updateData
         }));
       }
+      // Sync avatar across open tabs via localStorage
+      localStorage.setItem(`rh_avatar_${user.uid}`, editAvatar.trim());
 
       setToasts((prev) => [...prev, { id: Date.now() + Math.random(), message: "Profile updated successfully!", type: "success" }]);
       setIsEditModalOpen(false);


### PR DESCRIPTION
## Description

Fixes #550

The profile avatar doesn't update in other open tabs after being changed in settings. 

## Root Cause

The existing `onSnapshot` listener on the Firestore user document should handle cross-tab sync, but Firestore's local IndexedDB cache (shared across tabs in the same origin) can suppress the real-time callback when the cache is updated from another tab's write.

## Fix

- **Profile.jsx**: After updating the avatar in Firestore, write the new URL to localStorage using a namespaced key (`rh_avatar_${uid}`)
- **AuthContext.jsx**: Listen for the `window` `storage` event. When a cross-tab avatar change is detected, update `userData` state immediately

This pattern uses the browser's built-in cross-tab communication mechanism (`storage` events fire automatically in other tabs when localStorage changes) without requiring any external API.

## Testing

1. Open two RankerHub tabs
2. In Tab A, go to Profile settings and update the avatar
3. Switch to Tab B — the avatar should update within ~100ms without manual refresh