### PR TITLE
fix: prevent leaderboard rank numbers flashing wrong positions on initial load

### DIFF
--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -43,7 +43,7 @@ export const GitRank = () => {
   const handleCollegeChange = (e) => {
     const val = e.target.value;
     const newParams = new URLSearchParams(searchParams);
-    if (val) newParams.set("college", val);
+    if (val) newfParams.set("college", val);
     else newParams.delete("college");
     setSearchParams(newParams, { replace: true });
   };
@@ -125,8 +125,10 @@ export const GitRank = () => {
 
         setUsersList(ranked);
         setLastVisible(snapshot.docs[snapshot.docs.length - 1]);
-        setHasMore(snapshot.docs.length === 50); 
-        setLoadingUsers(false);
+        setHasMore(snapshot.docs.length === 50);
+        if (!snapshot.metadata.fromCache) {
+          setLoadingUsers(false);
+        }
       },
       (error) => {
         console.error("Leaderboard subscription error:", error);

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -43,7 +43,7 @@ export const GitRank = () => {
   const handleCollegeChange = (e) => {
     const val = e.target.value;
     const newParams = new URLSearchParams(searchParams);
-    if (val) newfParams.set("college", val);
+    if (val) newParams.set("college", val);
     else newParams.delete("college");
     setSearchParams(newParams, { replace: true });
   };


### PR DESCRIPTION
Fixes #552

## Root Cause
The leaderboard uses Firestore `onSnapshot` which fires twice on page load:
1. First with **cached data** (instant) — may be unsorted/stale
2. Then with **server data** — correct and authoritative

The loading state was cleared after the first callback (cache), causing rank numbers to flash incorrect positions for 1-2 seconds before jumping to the correct order.

## Fix
Added a `snapshot.metadata.fromCache` check so the loading spinner is only hidden when data arrives from the Firestore server, not from cache.

## Change
- `src/pages/GitRank.jsx` — wrap `setLoadingUsers(false)` in `if (!snapshot.metadata.fromCache)`