### PR TITLE
fix: prevent duplicate notification panels on rapid bell clicks

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -22,6 +22,7 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
     return "Good evening";
   })();
   const notificationRef = useRef(null);
+  const notificationToggleRef = useRef(false);
   const navigate = useNavigate();
 
   const hasSearchQuery = searchQuery.trim().length > 0;
@@ -283,7 +284,12 @@ export const Navbar = ({ toggleMobile, isMobileOpen }) => {
           <motion.button
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => setShowNotifications(!showNotifications)}
+            onClick={() => {
+              if (notificationToggleRef.current) return;
+              notificationToggleRef.current = true;
+              setShowNotifications(prev => !prev);
+              setTimeout(() => { notificationToggleRef.current = false; }, 300);
+            }}
             className="p-2 rounded-xl border border-slate-200/50 dark:border-slate-800/50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md text-slate-700 dark:text-slate-300 w-10 h-10 flex items-center justify-center cursor-pointer hover:shadow-sm relative"
           >
             <Bell className="w-5 h-5" />


### PR DESCRIPTION
Fixes #560

Added a `useRef` debounce guard (300ms) to the notification bell toggle to prevent multiple overlapping `AnimatePresence` panels from stacking when users click rapidly.

Also switched to functional state update (`setShowNotifications(prev => !prev)`) for more reliable toggle behavior.