### PR TITLE
fix: prevent dark mode flicker during SPA navigation

### DIFF
--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useState, useEffect } from "react";
+import React, { createContext, useState, useLayoutEffect } from "react";
 
 export const ThemeContext = createContext();
 
@@ -13,7 +13,8 @@ export const ThemeProvider = ({ children }) => {
     return systemPrefersDark ? "dark" : "light";
   });
 
-  useEffect(() => {
+  // Sync theme to DOM synchronously on mount (before paint)
+  useLayoutEffect(() => {
     const root = window.document.documentElement;
     if (theme === "dark") {
       root.classList.add("dark");

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
 @layer base {
   body {
     font-family: 'Outfit', 'Inter', system-ui, sans-serif;
-    @apply bg-slate-50 text-slate-800 antialiased transition-colors duration-300;
+    @apply bg-slate-50 text-slate-800 antialiased;
   }
 
   body.dark {


### PR DESCRIPTION
Fixes #558

### Root cause
The body had `transition-colors duration-300` which made color/background changes visible as a 300ms animation. Combined with `useEffect` (async, after paint) for theme syncing, this caused a visible white flash during page navigation.

### Changes
1. **Removed `transition-colors duration-300` from body** — prevents visible color transitions that caused the flash
2. **Switched `useEffect` → `useLayoutEffect`** — theme class is applied synchronously before browser paint

The blocking script in `index.html` already applies the dark class before React mounts; these changes ensure zero flicker during SPA navigation as well.