### PR TITLE
feat: add confirmation dialog before unfollowing

### DIFF
--- a/src/pages/Friends.jsx
+++ b/src/pages/Friends.jsx
@@ -152,7 +152,11 @@ export const Friends = () => {
 
   const handleToggleFollow = async (developerId) => {
     const isFollowing = followingIds.includes(developerId);
-    // Directly mutate Firebase. The onSnapshot listener will automatically update the UI!
+    if (isFollowing) {
+      const dev = developers.find(d => d.id === developerId);
+      const username = dev?.username || dev?.displayName || "this user";
+      if (!window.confirm(`Are you sure you want to unfollow @${username}?`)) return;
+    }
     await toggleFollowStatus(currentUser.uid, developerId, isFollowing);
   };
 


### PR DESCRIPTION
Fixes #553

Adds a `window.confirm` prompt when unfollowing a developer to prevent accidental unfollows (common on mobile). The confirm dialog shows the developer's username.

Only prompts for unfollow — following remains a single-click action.