### PR TITLE
fix: sync profile rank with leaderboard using gitRankPoints

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -301,7 +301,8 @@ if (updateData.avatar) {
       try {
         const q = query(
           collection(db, "users"),
-          where("points.totalPoints", ">", userData.points.totalPoints)
+          where("onboardingStatus", "==", "complete"),
+      where("points.gitRankPoints", ">", userData.points.gitRankPoints ?? 0)
         );
         const snapshot = await getCountFromServer(q);
         const currentRank = snapshot.data().count + 1;


### PR DESCRIPTION
## What's the bug?
Profile page showed rank based on `totalPoints` but the 
leaderboard ranked users by `gitRankPoints` — causing a mismatch.

## Fix
Updated `fetchRank` in `Profile.jsx` to query using 
`points.gitRankPoints` and filter `onboardingStatus == complete`, 
matching exactly how GitRank leaderboard calculates rank.

Closes #579