### PR TITLE
fix: close dropdown on outside tap on mobile

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -139,7 +139,11 @@ const [learningInput, setLearningInput] = useState("");
       }
     };
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+    };
   }, []);
 
   const handleOpenEditModal = () => {


### PR DESCRIPTION
## Bug
Tapping outside a dropdown on mobile didn't close it because 
the existing listener only handled `mousedown`, which doesn't 
fire on mobile touch devices.

## Fix
Added `touchstart` event listener alongside `mousedown` in 
Profile.jsx so dropdowns close correctly on both desktop and mobile.

Closes #581