### PR TITLE
 fix: update HubCoin balance in UI immediately after purchase

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -354,6 +354,11 @@ export const AuthProvider = ({ children }) => {
           updatedAt: new Date().toISOString()
         });
       });
+      setUserData(prev => ({
+        ...prev,
+        hubCoins: (prev.hubCoins ?? 0) - price,
+        inventory: [...(prev.inventory || ["oliver"]), mascotId],
+      }));
     } catch (err) {
       console.error("Failed to purchase mascot:", err);
       throw err;


### PR DESCRIPTION
## Bug
After buying a mascot from the shop, the HubCoin balance 
shown in the UI didn't update until the page was reopened.

## Root Cause
`purchaseMascot` in `AuthContext.jsx` correctly wrote the 
deducted balance to Firestore via a transaction, but never 
called `setUserData` to sync the local React state.

## Fix
Added `setUserData` call after the transaction succeeds to 
immediately reflect the new coin balance and updated inventory 
in the UI without requiring a page reload.

Closes #583