### PR TITLE
fix: handle special characters in GitHub username profile routes

### DIFF
--- a/src/components/friends/DeveloperCard.jsx
+++ b/src/components/friends/DeveloperCard.jsx
@@ -30,7 +30,7 @@ export const DeveloperCard = ({ developer, isFollowing, onToggleFollow, compact 
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
               <Link
-                to={`/dashboard/profile/${developer.username}`}
+                to={`/dashboard/profile/${encodeURIComponent(developer.username)}`}
                 className="font-extrabold text-slate-900 dark:text-white hover:text-violet-600 dark:hover:text-violet-400 transition-colors truncate block"
               >
                 {developer.name}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -42,7 +42,8 @@ import collegesList from "../data/colleges.json";
 export const Profile = () => {
   const navigate = useNavigate();
   const { userData: authUserData, user, setUserData, syncGitHubData } = useAuth();
-  const { username } = useParams();
+  const { username: rawUsername } = useParams();
+  const username = rawUsername ? decodeURIComponent(rawUsername) : undefined;
   const [publicProfile, setPublicProfile] = useState(null);
   const [loadingPublicProfile, setLoadingPublicProfile] = useState(!!username);
 


### PR DESCRIPTION
## Bug
Profile pages for GitHub usernames containing dots (e.g. "john.doe") 
crashed because the dot was misinterpreted by the router.

## Fix
- Encode the username with `encodeURIComponent` in `DeveloperCard.jsx` 
  when building profile links
- Decode it with `decodeURIComponent` in `Profile.jsx` when reading 
  the route param

This ensures dots, hyphens, and other valid GitHub username characters 
are handled correctly end-to-end.

Closes #584