### PR TITLE
feat: add recently visited profiles section on leaderboard

### DIFF
--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -1048,7 +1048,7 @@ const handleJumpToMyRank = async () => {
           </p>
           <div className="flex flex-wrap gap-2">
             {recentProfiles.map((p) => (
-              
+              <a
                 key={p.username}
                 href={`/dashboard/profile/${encodeURIComponent(p.username)}`}
                 className="flex items-center gap-2 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 hover:border-violet-500/40 hover:bg-violet-500/5 transition-all"

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -1038,52 +1038,7 @@ const handleJumpToMyRank = async () => {
 
       {/* 3. Leaderboard Table / Search & Filters Controls */}
       <Card className="!p-3 sm:!p-6">
-      {/* Issue #585: Recently Visited Profiles */}
-      {recentProfiles.length > 0 && (
-        <div className="mb-5">
-          <p className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-2">
-            🕐 Recently Visited
-          </p>
-          <div className="flex flex-wrap gap-2">
-            {recentProfiles.map((p) => (
-              
-                key={p.username}
-                href={`/dashboard/profile/${encodeURIComponent(p.username)}`}
-                className="flex items-center gap-2 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 hover:border-violet-500/40 hover:bg-violet-500/5 transition-all"
-              >
-                <img src={p.avatar} alt={p.name} className="w-5 h-5 rounded-full object-cover" />
-                <span className="text-xs font-bold text-slate-700 dark:text-slate-300">{p.name}</span>
-                <span className="text-[10px] text-slate-400">@{p.username}</span>
-              </a>
-            ))}
-          </div>
-        </div>
-      )}
-       
-      {/* Jump to My Rank - Issue #483 */}
-{user && (
-  <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 mb-4">
-    <button
-      onClick={handleJumpToMyRank}
-      disabled={rankLoading}
-      className="flex items-center gap-2 px-4 py-2 rounded-xl bg-violet-600 hover:bg-violet-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-bold transition-colors shadow-md"
-    >
-      {rankLoading ? "⏳ Finding rank..." : "📍 My Rank"}
-    </button>
-
-    {myRank && (
-      <div className="px-4 py-2 rounded-xl bg-violet-50 dark:bg-violet-500/10 border border-violet-200 dark:border-violet-500/20 text-violet-700 dark:text-violet-300 text-xs font-bold flex items-center gap-2">
-        🏅 You are ranked <span className="text-violet-600 dark:text-violet-400 font-black">#{myRank}</span> on the leaderboard
-      </div>
-    )}
-
-    {rankError && (
-      <div className="px-4 py-2 rounded-xl bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20 text-amber-700 dark:text-amber-300 text-xs font-bold flex items-center gap-2">
-        ⚠️ {rankError}
-      </div>
-    )}
-  </div>
-)}
+      
       
         {/* Issue #585: Recently Visited Profiles */}
       {recentProfiles.length > 0 && (

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -74,6 +74,13 @@ export const GitRank = () => {
   const [repos, setRepos] = useState([]);
   const [loadingCharts, setLoadingCharts] = useState(true);
   const [chartRateLimitError, setChartRateLimitError] = useState("");
+  // Issue #585: Recently visited profiles from localStorage
+  const [recentProfiles, setRecentProfiles] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem("rh_recently_visited") || "[]");
+    } catch { return []; }
+  });
+
   // Jump to My Rank
 const [myRank, setMyRank] = useState(null);
 const [rankLoading, setRankLoading] = useState(false);
@@ -1057,7 +1064,29 @@ const handleJumpToMyRank = async () => {
   </div>
 )}
       
-        {/* NEW TAB SYSTEM FOR REFERRAL LEADERBOARD */}
+        {/* Issue #585: Recently Visited Profiles */}
+      {recentProfiles.length > 0 && (
+        <div className="mb-5">
+          <p className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+            🕐 Recently Visited
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {recentProfiles.map((p) => (
+              
+                key={p.username}
+                href={`/dashboard/profile/${encodeURIComponent(p.username)}`}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 hover:border-violet-500/40 hover:bg-violet-500/5 transition-all"
+              >
+                <img src={p.avatar} alt={p.name} className="w-5 h-5 rounded-full object-cover" />
+                <span className="text-xs font-bold text-slate-700 dark:text-slate-300">{p.name}</span>
+                <span className="text-[10px] text-slate-400">@{p.username}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* NEW TAB SYSTEM FOR REFERRAL LEADERBOARD */}
         
         <div className="flex items-center gap-2 mb-6 p-1 bg-slate-100 dark:bg-slate-800/50 rounded-xl w-fit">
           <button

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -1038,6 +1038,27 @@ const handleJumpToMyRank = async () => {
 
       {/* 3. Leaderboard Table / Search & Filters Controls */}
       <Card className="!p-3 sm:!p-6">
+      {/* Issue #585: Recently Visited Profiles */}
+      {recentProfiles.length > 0 && (
+        <div className="mb-5">
+          <p className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-2">
+            🕐 Recently Visited
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {recentProfiles.map((p) => (
+              
+                key={p.username}
+                href={`/dashboard/profile/${encodeURIComponent(p.username)}`}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 hover:border-violet-500/40 hover:bg-violet-500/5 transition-all"
+              >
+                <img src={p.avatar} alt={p.name} className="w-5 h-5 rounded-full object-cover" />
+                <span className="text-xs font-bold text-slate-700 dark:text-slate-300">{p.name}</span>
+                <span className="text-[10px] text-slate-400">@{p.username}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
        
       {/* Jump to My Rank - Issue #483 */}
 {user && (

--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -75,7 +75,7 @@ export const GitRank = () => {
   const [loadingCharts, setLoadingCharts] = useState(true);
   const [chartRateLimitError, setChartRateLimitError] = useState("");
   // Issue #585: Recently visited profiles from localStorage
-  const [recentProfiles, setRecentProfiles] = useState(() => {
+  const [recentProfiles] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem("rh_recently_visited") || "[]");
     } catch { return []; }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -71,7 +71,22 @@ export const Profile = () => {
         const q1 = query(collection(db, "users"), where("githubUsername", "==", username));
         const snapshot1 = await getDocs(q1);
         if (!snapshot1.empty) {
-          setPublicProfile(snapshot1.docs[0].data());
+          const profileData = snapshot1.docs[0].data();
+          setPublicProfile(profileData);
+          // Issue #585: Save to recently visited profiles in localStorage
+          try {
+            const key = "rh_recently_visited";
+            const existing = JSON.parse(localStorage.getItem(key) || "[]");
+            const entry = {
+              username: profileData.githubUsername,
+              name: profileData.name,
+              avatar: profileData.avatar,
+              visitedAt: Date.now()
+            };
+            const filtered = existing.filter(e => e.username !== entry.username);
+            const updated = [entry, ...filtered].slice(0, 5);
+            localStorage.setItem(key, JSON.stringify(updated));
+          } catch {}
         } else {
           const docRef = doc(db, "users", username);
           const docSnap = await getDoc(docRef);

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -86,7 +86,7 @@ export const Profile = () => {
             const filtered = existing.filter(e => e.username !== entry.username);
             const updated = [entry, ...filtered].slice(0, 5);
             localStorage.setItem(key, JSON.stringify(updated));
-          } catch {}
+          } catch (e) { console.error(e); }
         } else {
           const docRef = doc(db, "users", username);
           const docSnap = await getDoc(docRef);


### PR DESCRIPTION
## Feature
Added a "Recently Visited" profiles section on the GitRank 
leaderboard page, so users can quickly navigate back to 
profiles they checked before.

## Implementation
- When a public profile is viewed in `Profile.jsx`, the 
  user's name, avatar, and username are saved to localStorage 
  under `rh_recently_visited` (max 5 entries, newest first)
- On the GitRank leaderboard page `GitRank.jsx`, a small 
  pill-style row shows the last visited profiles with avatar, 
  name, and username — each linking directly to that profile
- Persists across sessions via localStorage

Closes #585