### PR TITLE
fix: auto re-render streak card at midnight

### DIFF
--- a/src/components/dashboard/StreakCard.jsx
+++ b/src/components/dashboard/StreakCard.jsx
@@ -6,7 +6,19 @@ import { toLocalDateString, resolveTimezone } from "../../utils/streakCalculator
 
 export const StreakCard = () => {
   const { userData } = useAuth();
-  
+  const [, setTick] = React.useState(0);
+
+  // Issue #586: Re-render at midnight so streak updates without page refresh
+  React.useEffect(() => {
+    const now = new Date();
+    const msUntilMidnight =
+      new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 5).getTime() - now.getTime();
+    const timer = setTimeout(() => {
+      setTick(t => t + 1);
+    }, msUntilMidnight);
+    return () => clearTimeout(timer);
+  }, []);
+
   const activeStreak = userData?.streak || 0;
   const longestStreak = Math.max(userData?.longestStreak || 0, activeStreak);
   const streakFreezes = userData?.streakFreezes || 0;


### PR DESCRIPTION
## Bug
The streak count on the dashboard showed stale data if the 
page was kept open across midnight. The `now` variable was 
only calculated once at render time and never updated.

## Fix
Added a `useEffect` in `StreakCard.jsx` that sets a timeout 
to fire exactly at midnight (+ 5 seconds buffer), triggering 
a re-render so the streak display updates automatically 
without requiring a page refresh.

Closes #586
