### PR TITLE
fix(#564): use stable function reference for storage event listener

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -233,8 +233,8 @@ export const AuthProvider = ({ children }) => {
       }
     };
 
-    window.addEventListener("storage", e => handleStorageChange(e));
-    return () => window.removeEventListener("storage", e => handleStorageChange(e));
+    window.addEventListener("storage", handleStorageChange);
+    return () => window.removeEventListener("storage", handleStorageChange);
   }, []);
 
   const login = async (requestRepoScope = true) => {


### PR DESCRIPTION
Fixes #564

Replaces anonymous arrow function wrappers with a direct reference to \handleStorageChange\, ensuring \emoveEventListener\ actually removes the registered listener and prevents memory leaks.