### PR TITLE
fix: prevent Toast auto-dismiss timer from resetting on every parent re-render

### DIFF
--- a/src/components/ui/Toast.jsx
+++ b/src/components/ui/Toast.jsx
@@ -1,11 +1,24 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 
 export const Toast = ({ message, type = "success", onClose }) => {
+  // Keep the latest onClose in a ref so the auto-dismiss timer always calls
+  // the most recent callback without onClose needing to be a reactive
+  // dependency. This prevents the 3-second timer from resetting every time
+  // the parent re-renders and passes a new inline onClose function.
+  const onCloseRef = useRef(onClose);
+
   useEffect(() => {
-    const timer = setTimeout(onClose, 3000);
-    return () => clearTimeout(timer);
+    onCloseRef.current = onClose;
   }, [onClose]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onCloseRef.current();
+    }, 3000);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <motion.div


### PR DESCRIPTION
Fixes #545

Problem:
The useEffect setting Toast's 3-second auto-dismiss timer listed onClose as a dependency. Since call sites (e.g. Profile.jsx) pass onClose as an inline arrow function, it's a new reference on every parent render, causing the effect to re-run and reset the timer. If the parent re-renders before 3 seconds (e.g. due to a Firestore snapshot update), the toast never auto-dismisses.

Fix:
Captured onClose in a ref (onCloseRef) that's kept up to date via a separate effect. The timer-setting effect now has an empty dependency array, so it only runs once on mount and always calls the latest onClose via the ref — the timer is no longer affected by parent re-renders.

Files changed:
- src/components/ui/Toast.jsx

Testing:
- Verified a toast auto-dismisses after exactly 3 seconds even when the parent component re-renders multiple times within that window.
- Verified manual close behavior (if applicable) still works via the latest onClose reference.