### PR TITLE
fix: ErrorBoundary resets in-place instead of forcing a full page reload

### DIFF
--- a/src/components/ui/ErrorBoundary.jsx
+++ b/src/components/ui/ErrorBoundary.jsx
@@ -4,6 +4,7 @@ export class ErrorBoundary extends Component {
   constructor(props) {
     super(props);
     this.state = { hasError: false, error: null };
+    this.resetError = this.resetError.bind(this);
   }
 
   static getDerivedStateFromError(error) {
@@ -12,6 +13,10 @@ export class ErrorBoundary extends Component {
 
   componentDidCatch(error, errorInfo) {
     console.error("ErrorBoundary caught an error:", error, errorInfo);
+  }
+
+  resetError() {
+    this.setState({ hasError: false, error: null });
   }
 
   render() {
@@ -39,12 +44,20 @@ export class ErrorBoundary extends Component {
             <p className="text-sm text-slate-500 dark:text-slate-400 mb-6 font-medium">
               The application encountered an unexpected error. Don't worry, your data is safe.
             </p>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-6 py-2.5 rounded-xl bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white font-semibold shadow-lg hover:shadow-indigo-500/20 active:scale-95 transition-all duration-200 cursor-pointer"
-            >
-              Refresh Page
-            </button>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={this.resetError}
+                className="px-6 py-2.5 rounded-xl bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white font-semibold shadow-lg hover:shadow-indigo-500/20 active:scale-95 transition-all duration-200 cursor-pointer"
+              >
+                Try Again
+              </button>
+              <button
+                onClick={() => window.location.reload()}
+                className="px-6 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 font-semibold transition-all duration-200 cursor-pointer"
+              >
+                Reload Page
+              </button>
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
Fixes #546

Problem:
The ErrorBoundary's recovery button called window.location.reload(), forcing a full browser page reload. This loses all in-memory React state, clears the Firebase Auth session cache (requiring full re-authentication), and discards any unsaved user data — when the standard recovery pattern is to reset the error boundary's own state and let React re-render the subtree in-place.

Fix:
Added a resetError method that resets hasError/error state, wired to a new "Try Again" button as the primary recovery action. Kept a secondary "Reload Page" button for cases where in-place recovery isn't sufficient.

Files changed:
- src/components/ui/ErrorBoundary.jsx

Testing:
- Verified triggering a render error shows the error UI.
- Verified "Try Again" resets the boundary and re-renders the child tree without a full page reload.
- Verified "Reload Page" still performs a full reload as a fallback.