### PR TITLE
fix: handle iOS safe area insets for bottom nav overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <!-- Google Fonts (clean way) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/layouts/DashboardLayout.jsx
+++ b/src/layouts/DashboardLayout.jsx
@@ -43,6 +43,7 @@ export const DashboardLayout = () => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.35, ease: "easeOut" }}
           className="flex-1 p-4 md:p-6 lg:p-8 max-w-7xl w-full mx-auto"
+          style={{ paddingBottom: "calc(2rem + env(safe-area-inset-bottom))" }}
         >
           <Outlet />
         </motion.main>


### PR DESCRIPTION
## Changes Made
- Added `viewport-fit=cover` to the viewport meta tag in `index.html` to enable iOS safe area inset support
- Added `env(safe-area-inset-bottom)` padding to the main content area in `DashboardLayout.jsx` so content isn't hidden behind the iPhone home indicator

## Why
On iPhones with a home bar (iPhone X and later), the bottom nav was overlapping page content because safe area insets weren't being handled.

Closes #614