### PR TITLE
fix: add visual cooldown progress bar for sync button

### DIFF
--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -780,6 +780,19 @@ export const GitRank = () => {
                       : "Sync Data"}
                 </GradientButton>
 
+                {cooldownSeconds > 0 && (
+                  <div className="w-full">
+                    <div className="w-full h-1.5 bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-violet-500 rounded-full transition-all duration-1000"
+                        style={{ width: `${(cooldownSeconds / 300) * 100}%` }}
+                      />
+                    </div>
+                    <p className="text-[10px] text-slate-400 font-medium text-center mt-1">
+                      Cooldown: {formatCooldown(cooldownSeconds)} remaining
+                    </p>
+                  </div>
+                )}
                 {userData?.lastSync && (
                   <span className="text-[10px] sm:text-xs text-slate-400 font-medium">
                     Last sync:{" "}


### PR DESCRIPTION
## Bug
The sync button showed a text countdown ("Retry in Xm Xs") 
during cooldown but it was easy to miss and gave no visual 
sense of progress.

## Fix
Added a violet progress bar under the sync button that 
depletes over the 5-minute cooldown period, along with a 
"Cooldown: Xm Xs remaining" label — making it immediately 
clear to users that the button is on cooldown and how long 
until they can sync again.

Closes #616