### PR TITLE
Fix: leaderboard resets loaded entries when live listener refreshes

### DIFF
--- a/src/pages/GitRank.jsx
+++ b/src/pages/GitRank.jsx
@@ -219,7 +219,10 @@ export const GitRank = () => {
           rank: i + 1,
         }));
 
-        setUsersList(ranked);
+        setUsersList((prev) => {
+  const extraPages = prev.slice(50); // users loaded via "Load More"
+  return [...ranked, ...extraPages].map((u, i) => ({ ...u, rank: i + 1 }));
+});
         setLastVisible(snapshot.docs[snapshot.docs.length - 1]);
         setHasMore(snapshot.docs.length === 50);
         if (!snapshot.metadata.fromCache) {


### PR DESCRIPTION
Closes #618

## Problem
Clicking "Load More" on the leaderboard correctly appended new users to the list. However, the live Firestore `onSnapshot` listener (which watches the top 50 users) re-fires periodically and was overwriting the entire `usersList` state with just those 50 users — wiping out any additional users loaded via pagination. Since the virtualized table's scroll position no longer matched the now-shorter list, this appeared as the page snapping back to the top.

## Fix
Updated the `onSnapshot` callback in `GitRank.jsx` to merge the refreshed top-50 data with any additional pages already loaded, instead of replacing the whole list:

\`\`\`js
setUsersList((prev) => {
  const extraPages = prev.slice(50);
  return [...ranked, ...extraPages].map((u, i) => ({ ...u, rank: i + 1 }));
});
\`\`\`

## Testing
Local Firebase env isn't configured in this fork, so live Firestore behavior couldn't be tested end-to-end locally. The dev server runs cleanly with no errors. Would appreciate a check on the preview deployment to confirm scroll position now holds after "Load More" + listener refresh.